### PR TITLE
Add app library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/nestor_api/lib/app.py
+++ b/nestor_api/lib/app.py
@@ -1,0 +1,15 @@
+"""Application library"""
+
+def get_version():
+    """Get the application version"""
+
+    # Awaiting for implementation
+
+    # Takes as a parameter an application directory path to determine its version
+
+    # Previously tied to package.json (for Node.JS)
+    # Either :
+    # - Make it independent from language
+    # - Implement different languages support
+
+    return "0.0.0"

--- a/tests/lib/test_app.py
+++ b/tests/lib/test_app.py
@@ -1,0 +1,8 @@
+# pylint: disable=missing-function-docstring disable=missing-module-docstring
+
+import nestor_api.lib.app as app
+
+
+def test_get_version():
+    version = app.get_version()
+    assert version == "0.0.0"


### PR DESCRIPTION
This adds the app library.
For now it is more of an empty shell.

Previously it was coupled to package.json of node.js projects. But we want to support other way of versioning in applications.