### PR TITLE
Update the way we pass app_config to the lib functions

### DIFF
--- a/nestor_api/lib/config.py
+++ b/nestor_api/lib/config.py
@@ -71,6 +71,7 @@ def _resolve_variable(template: str, variables: dict, path: str) -> str:
                     )
 
                 final_value = re.sub(f"{{{{{var_name}}}}}", var_value, final_value)
+        return final_value
 
     # Resolve pattern '$ENV_VAR'
     env_variables = re.findall(r"^\$(\w+)$", template)
@@ -78,6 +79,7 @@ def _resolve_variable(template: str, variables: dict, path: str) -> str:
         env_var = os.environ.get(env_variables[0])
         if env_var is not None:
             final_value = env_var
+        return final_value
 
     # Awaiting for implementation
     # -> Resolve vault definitions "!vault:xxx"

--- a/nestor_api/lib/config.py
+++ b/nestor_api/lib/config.py
@@ -26,18 +26,18 @@ def create_temporary_config_copy() -> str:
     return io.create_temporary_copy(Configuration.get_config_path(), "config")
 
 
-def get_app_config(app_name: str) -> dict:
+def get_app_config(app_name: str, config_path: str = Configuration.get_config_path()) -> dict:
     """Load the configuration of an app"""
     app_config_path = os.path.join(
-        Configuration.get_config_path(), Configuration.get_config_app_folder(), f"{app_name}.yaml",
+        config_path, Configuration.get_config_app_folder(), f"{app_name}.yaml",
     )
     if not io.exists(app_config_path):
         raise AppConfigurationNotFoundError(app_name)
 
     app_config = io.from_yaml(app_config_path)
-    environment_config = get_project_config()
+    project_config = get_project_config(config_path)
 
-    config = dict_utils.deep_merge(environment_config, app_config)
+    config = dict_utils.deep_merge(project_config, app_config)
 
     # Awaiting for implementation
     # validate configuration using nestor-config-validator
@@ -45,11 +45,9 @@ def get_app_config(app_name: str) -> dict:
     return _resolve_variables_deep(config)
 
 
-def get_project_config() -> dict:
-    """Load the configuration of the current environment (global configuration)"""
-    project_config_path = os.path.join(
-        Configuration.get_config_path(), Configuration.get_config_project_filename()
-    )
+def get_project_config(config_path: str = Configuration.get_config_path()) -> dict:
+    """Load the global configuration of the project"""
+    project_config_path = os.path.join(config_path, Configuration.get_config_project_filename())
     if not io.exists(project_config_path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), project_config_path)
 
@@ -63,13 +61,23 @@ def _resolve_variable(template: str, variables: dict, path: str) -> str:
 
     # Resolve pattern '{{variable}}'
     referenced_names = re.findall(r"{{([\w\-.]+)}}", template)
-    for var_name in referenced_names:
-        var_value = variables.get(var_name)
-        if var_value is not None:
-            if not isinstance(var_value, str):
-                raise ConfigurationError(path, "Referenced variable should resolved to a string")
+    if len(referenced_names) > 0:
+        for var_name in referenced_names:
+            var_value = variables.get(var_name)
+            if var_value is not None:
+                if not isinstance(var_value, str):
+                    raise ConfigurationError(
+                        path, "Referenced variable should resolved to a string"
+                    )
 
-            final_value = re.sub(f"{{{{{var_name}}}}}", var_value, final_value)
+                final_value = re.sub(f"{{{{{var_name}}}}}", var_value, final_value)
+
+    # Resolve pattern '$ENV_VAR'
+    env_variables = re.findall(r"^\$(\w+)$", template)
+    if len(env_variables) > 0:
+        env_var = os.environ.get(env_variables[0])
+        if env_var is not None:
+            final_value = env_var
 
     # Awaiting for implementation
     # -> Resolve vault definitions "!vault:xxx"

--- a/nestor_api/lib/docker.py
+++ b/nestor_api/lib/docker.py
@@ -1,19 +1,12 @@
 """Docker library"""
 
-import nestor_api.lib.config as config
 import nestor_api.lib.git as git
 import nestor_api.lib.io as io
 from nestor_api.utils.logger import Logger
 
 
-def build(app_name, context):
-    """Build the docker image of the last version of the app
-    Example:
-        > app_name = "my-app"
-        > context = {"repository": "/path_to/my-app-doc", "commit_hash": "a2b3c4"}
-        > build(app_name, context)
-    """
-    repository = context["repository"]
+def build(app_name: str, repository: str, app_config: dict) -> str:
+    """Build the docker image of the last version of the app"""
     image_tag = git.get_last_tag(repository)
 
     Logger.info(
@@ -24,16 +17,15 @@ def build(app_name, context):
         Logger.info({}, "Docker image already built (skipped)")
         return image_tag
 
-    app_config = config.get_app_config(app_name)
-    commit_hash = context["commit_hash"]
-    build_variables = app_config["build"]["variables"]
+    commit_hash = git.get_commit_hash_from_tag(repository, image_tag)
+    build_variables = app_config.get("docker", {}).get("build", {}).get("variables", {})
+    build_variables["COMMIT_HASH"] = commit_hash
 
     # Application build environment variables:
     builds_args = []
     for key, value in build_variables.items():
         builds_args.append(f"--build-arg {key}={value}")
 
-    builds_args.append(f"--build-arg COMMIT_HASH={commit_hash}")
     builds_args_str = " ".join(builds_args)
 
     command = f"docker build --tag {app_name}:{image_tag} {builds_args_str} {repository}"
@@ -49,30 +41,26 @@ def build(app_name, context):
     return image_tag
 
 
-def has_docker_image(app_name, tag):
+def has_docker_image(app_name: str, tag: str) -> bool:
     """Checks if the docker image already exists for a given app and tag"""
     stdout = io.execute(f"docker images {app_name}:{tag} --quiet")
     return len(stdout) != 0
 
 
-def get_registry_image_tag(app_name, image_tag, registry):
+def get_registry_image_tag(app_name: str, image_tag: str, registry: dict) -> str:
     """Returns the image name for a given organization, app and tag"""
     return f"{registry['organization']}/{app_name}:{image_tag}"
 
 
-def push(app_name, repository):
+def push(app_name: str, image_tag: str, app_config: dict) -> None:
     """Push an image to the configured docker registry"""
-
-    # This will need to be done a bit differently to work with GCP registry
-
-    app_config = config.get_app_config(app_name)
-
-    image_tag = git.get_last_tag(repository)
-
     if not has_docker_image(app_name, image_tag):
         raise RuntimeError("Docker image not available")
 
-    registry = app_config["docker"]["registry"]
+    # This will need to be done a bit differently to work with other registries (GCP)
+    # -> the config schema currently expects
+    #   {docker: {registries: {[name: string]: {id: string, organization: string}[]}}}
+    registry = app_config["docker"]["registries"]["docker.com"][0]
 
     # Create the tag
     image = get_registry_image_tag(app_name, image_tag, registry)

--- a/nestor_api/lib/git.py
+++ b/nestor_api/lib/git.py
@@ -33,22 +33,22 @@ def create_working_repository(app_name: str, git_url: str) -> str:
 
 def get_last_tag(repository_dir: str) -> str:
     """Retrieves the last tag of a repository (locally)"""
-    return io.execute("git describe --always --abbrev=0", repository_dir).rstrip()
+    return io.execute("git describe --always --abbrev=0", repository_dir)
 
 
 def get_remote_url(repository_dir: str, remote_name: str = "origin") -> str:
     """Retrieves the remote url of a repository"""
-    return io.execute(f"git remote get-url {remote_name}", repository_dir).rstrip()
+    return io.execute(f"git remote get-url {remote_name}", repository_dir)
 
 
 def get_last_commit_hash(repository_dir: str) -> str:
     """Retrieves the last commit hash of a repository (locally)"""
-    return io.execute("git rev-parse --short HEAD", repository_dir).rstrip()
+    return io.execute("git rev-parse --short HEAD", repository_dir)
 
 
 def get_commit_hash_from_tag(repository_dir: str, tag_name: str) -> str:
     """Returns the commit hash associated to the given tag"""
-    return io.execute(f"git rev-list -1 {tag_name}", repository_dir).rstrip()
+    return io.execute(f"git rev-list -1 {tag_name}", repository_dir)
 
 
 def push(repository_dir: str, branch_name: str = "HEAD") -> None:

--- a/nestor_api/lib/git.py
+++ b/nestor_api/lib/git.py
@@ -2,12 +2,11 @@
 
 import semver
 
-import nestor_api.lib.config as config
 import nestor_api.lib.io as io
 from nestor_api.utils.logger import Logger
 
 
-def branch(repository_dir, branch_name):
+def branch(repository_dir: str, branch_name: str) -> None:
     """Checkout a branch of a repository"""
     Logger.debug({"path": repository_dir}, "[git#branch] Repository path")
 
@@ -18,48 +17,47 @@ def branch(repository_dir, branch_name):
     io.execute(f'git checkout{"" if exists else " -b"} {branch_name}', repository_dir)
 
 
-def create_working_repository(app_name):
-    """Checkout a branch of a repository"""
-    # First, update the pristine repository for this app
-    pristine_directory = update_pristine_repository(app_name)
+def create_working_repository(app_name: str, git_url: str) -> str:
+    """Create a working copy of an app's repository"""
+    pristine_directory = update_pristine_repository(app_name, git_url)
 
     repository_dir = io.create_temporary_copy(pristine_directory, app_name)
 
     Logger.debug(
-        {app_name, repository_dir}, "[git#create_working_directory] Created a working repository",
+        {"app": app_name, "repository": repository_dir},
+        "[git#create_working_directory] Created a working repository",
     )
 
     return repository_dir
 
 
-def get_last_tag(repository_dir):
+def get_last_tag(repository_dir: str) -> str:
     """Retrieves the last tag of a repository (locally)"""
-    return io.execute("git describe --always --abbrev=0", repository_dir)
+    return io.execute("git describe --always --abbrev=0", repository_dir).rstrip()
 
 
-def get_remote_url(repository_dir, remote_name="origin"):
+def get_remote_url(repository_dir: str, remote_name: str = "origin") -> str:
     """Retrieves the remote url of a repository"""
-    return io.execute(f"git remote get-url {remote_name}", repository_dir)
+    return io.execute(f"git remote get-url {remote_name}", repository_dir).rstrip()
 
 
-def get_last_commit_hash(repository_dir):
+def get_last_commit_hash(repository_dir: str) -> str:
     """Retrieves the last commit hash of a repository (locally)"""
-    return io.execute("git rev-parse --short HEAD", repository_dir)
+    return io.execute("git rev-parse --short HEAD", repository_dir).rstrip()
 
 
-def push(repository_dir, branch_name="HEAD"):
+def get_commit_hash_from_tag(repository_dir: str, tag_name: str) -> str:
+    """Returns the commit hash associated to the given tag"""
+    return io.execute(f"git rev-list -1 {tag_name}", repository_dir).rstrip()
+
+
+def push(repository_dir: str, branch_name: str = "HEAD") -> None:
     """Push to the remote repository"""
     io.execute(f"git push origin {branch_name} --tags --follow-tags", repository_dir)
 
 
-def tag(repository_dir, app_name, tag_name):
+def tag(repository_dir: str, tag_name: str, tag_message: str = "Nestor auto-tag") -> str:
     """Add a tag to the repository"""
-    app_config = config.get_app_config(app_name)
-
-    # Move to the corresponding environment branch
-    branch(repository_dir, app_config.get("workflow")[0])
-
-    # Extract the last commit hash:
     commit_hash = get_last_commit_hash(repository_dir)
 
     final_tag = f"{tag_name}-sha-{commit_hash}"
@@ -67,28 +65,26 @@ def tag(repository_dir, app_name, tag_name):
     if not semver.VersionInfo.isvalid(final_tag):
         raise RuntimeError(f'Invalid version tag: "{final_tag}".')
 
-    io.execute(f"git tag -a {final_tag} {commit_hash}", repository_dir)
+    io.execute(f"git tag -a {final_tag} {commit_hash} -m {tag_message}", repository_dir)
 
     return final_tag
 
 
-def update_pristine_repository(app_name):
+def update_pristine_repository(app_name: str, git_url: str) -> str:
     """Update the pristine repository of an application"""
-    app_config = config.get_app_config(app_name)
-
     repository_dir = io.get_pristine_path(app_name)
 
-    update_repository(repository_dir, app_config.get("git").get("origin"))
+    update_repository(repository_dir, git_url)
 
     Logger.debug(
-        {app_name, repository_dir},
+        {"app": app_name, "repository": repository_dir},
         "[git#update_pristine_repository] Updated a pristine repository",
     )
 
     return repository_dir
 
 
-def update_repository(repository_dir, git_url, revision="origin/master"):
+def update_repository(repository_dir: str, git_url: str, revision: str = "origin/master") -> None:
     """Get the latest version of a revision or clone the repository"""
     should_clone = True
 
@@ -115,4 +111,5 @@ def update_repository(repository_dir, git_url, revision="origin/master"):
 
     if should_clone:
         io.execute(f"git clone {git_url} {repository_dir}")
+
     io.execute(f"git reset --hard {revision}", repository_dir)

--- a/nestor_api/lib/io.py
+++ b/nestor_api/lib/io.py
@@ -44,7 +44,7 @@ def execute(command: str, cwd=None):
     result = subprocess.run(
         command.split(), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=True, cwd=cwd,
     )
-    return result.stdout.decode("utf-8")
+    return result.stdout.decode("utf-8").rstrip()
 
 
 def exists(file_path):

--- a/nestor_api/lib/io.py
+++ b/nestor_api/lib/io.py
@@ -41,7 +41,9 @@ def ensure_dir(directory_path):
 
 def execute(command: str, cwd=None):
     """Executes a command and returns the stdout from it"""
-    result = subprocess.run(command.split(), stdout=subprocess.PIPE, check=True, cwd=cwd)
+    result = subprocess.run(
+        command.split(), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=True, cwd=cwd,
+    )
     return result.stdout.decode("utf-8")
 
 

--- a/tests/api/api_routes/test_sample.py
+++ b/tests/api/api_routes/test_sample.py
@@ -1,5 +1,3 @@
-# pylint: disable=missing-class-docstring disable=missing-function-docstring disable=missing-module-docstring
-
 """Test nestor_api.api.api_routes.sample."""
 from unittest import TestCase
 

--- a/tests/api/public_routes/test_heartbeat.py
+++ b/tests/api/public_routes/test_heartbeat.py
@@ -1,5 +1,3 @@
-# pylint: disable=missing-class-docstring disable=missing-function-docstring disable=missing-module-docstring
-
 """Test nestor_api.api.public_routes.heartbeat."""
 from unittest import TestCase
 

--- a/tests/config_validator/test_config.py
+++ b/tests/config_validator/test_config.py
@@ -1,5 +1,3 @@
-# pylint: disable=missing-function-docstring,missing-module-docstring
-
 from validator.config.config import Configuration
 
 

--- a/tests/config_validator/test_validate.py
+++ b/tests/config_validator/test_validate.py
@@ -1,5 +1,3 @@
-# pylint: disable=missing-function-docstring,missing-module-docstring
-
 import os
 from pathlib import Path
 
@@ -66,7 +64,9 @@ def test_validate_invalid_file():
 
 def test_validate_error_apps_dir_not_exists(mocker):
     mocker.patch.object(config_validator, "build_apps_path", return_value="some/target/path")
-    expected_message = "some/target/path does not look like a valid configuration path. Verify the path exists"  # pylint: disable=line-too-long
+    expected_message = (
+        "some/target/path does not look like a valid configuration path. Verify the path exists"
+    )
     with pytest.raises(Exception, match=expected_message):
         config_validator.validate_deployment_files()
 
@@ -75,9 +75,11 @@ def test_validate_error_validation_target(mocker):
     fixtures_path = Path(os.path.dirname(__file__), "..", "__fixtures__").resolve()
     mocker.patch.object(config_validator, "build_apps_path", return_value=fixtures_path)
     mocker.patch.object(Configuration, "get_validation_target", return_value="SOME_VALUE")
+    # pylint: disable=bad-continuation
     with pytest.raises(
-        Exception,  # pylint: disable=bad-continuation
-        match="There is no configuration to be validated. Be sure to define a valid NESTOR_VALIDATION_TARGET",  # pylint: disable=bad-continuation,line-too-long
+        Exception,
+        match="There is no configuration to be validated."
+        " Be sure to define a valid NESTOR_VALIDATION_TARGET",
     ):
         config_validator.validate_deployment_files()
 

--- a/tests/lib/test_app.py
+++ b/tests/lib/test_app.py
@@ -1,5 +1,3 @@
-# pylint: disable=missing-class-docstring disable=missing-function-docstring disable=missing-module-docstring
-
 from unittest import TestCase
 
 import nestor_api.lib.app as app

--- a/tests/lib/test_docker.py
+++ b/tests/lib/test_docker.py
@@ -5,50 +5,55 @@ from unittest.mock import call, patch
 import nestor_api.lib.docker as docker
 
 
-# pylint: disable=no-self-use
 class TestDockerLib(TestCase):
     @patch("nestor_api.lib.docker.has_docker_image", autospec=True)
     @patch("nestor_api.lib.docker.git", autospec=True)
-    def test_build_already_built(self, git_mock, has_docker_image_mock):
+    @patch("nestor_api.lib.docker.io", autospec=True)
+    def test_build_already_built(self, io_mock, git_mock, has_docker_image_mock):
         # Mocks
         has_docker_image_mock.return_value = True
         git_mock.get_last_tag.return_value = "1.0.0-sha-a2b3c4"
-        context = {"commit_hash": "a2b3c4", "repository": "/path_to/a_git_repository"}
 
         # Tests
-        image_tag = docker.build("my-app", context)
+        repository = "/path_to/a_git_repository"
+        app_config = {}
+
+        image_tag = docker.build("my-app", repository, app_config)
 
         # Assertions
         git_mock.get_last_tag.assert_called_once_with("/path_to/a_git_repository")
         has_docker_image_mock.assert_called_once_with("my-app", "1.0.0-sha-a2b3c4")
+        io_mock.execute.assert_not_called()
         self.assertEqual(image_tag, "1.0.0-sha-a2b3c4")
 
     @patch("nestor_api.lib.docker.has_docker_image", autospec=True)
     @patch("nestor_api.lib.docker.git", autospec=True)
-    @patch("nestor_api.lib.docker.config", autospec=True)
     @patch("nestor_api.lib.docker.io", autospec=True)
-    def test_build(self, io_mock, config_mock, git_mock, has_docker_image_mock):
+    def test_build(self, io_mock, git_mock, has_docker_image_mock):
         # Mocks
-        app_config = {"build": {"variables": {"var1": "val1", "var2": "val2"}}}
         has_docker_image_mock.return_value = False
         git_mock.get_last_tag.return_value = "1.0.0-sha-a2b3c4"
-        config_mock.get_app_config.return_value = app_config
+        git_mock.get_commit_hash_from_tag.return_value = "a2b3c4d5e6"
         io_mock.execute.return_value = ""
 
         # Tests
-        context = {"commit_hash": "a2b3c4", "repository": "/path_to/a_git_repository"}
-        image_tag = docker.build("my-app", context)
+        repository = "/path_to/a_git_repository"
+        app_config = {"docker": {"build": {"variables": {"var1": "val1", "var2": "val2"}}}}
+
+        image_tag = docker.build("my-app", repository, app_config)
 
         # Assertions
         git_mock.get_last_tag.assert_called_once_with("/path_to/a_git_repository")
+        git_mock.get_commit_hash_from_tag.assert_called_once_with(
+            "/path_to/a_git_repository", "1.0.0-sha-a2b3c4"
+        )
         has_docker_image_mock.assert_called_once_with("my-app", "1.0.0-sha-a2b3c4")
-        config_mock.get_app_config.assert_called_once_with("my-app")
         io_mock.execute.assert_called_once_with(
             "docker build"
             " --tag my-app:1.0.0-sha-a2b3c4"
             " --build-arg var1=val1"
             " --build-arg var2=val2"
-            " --build-arg COMMIT_HASH=a2b3c4"
+            " --build-arg COMMIT_HASH=a2b3c4d5e6"
             " /path_to/a_git_repository"
         )
         self.assertEqual(image_tag, "1.0.0-sha-a2b3c4")
@@ -56,36 +61,32 @@ class TestDockerLib(TestCase):
     @patch("nestor_api.lib.docker.Logger", autospec=True)
     @patch("nestor_api.lib.docker.has_docker_image", autospec=True)
     @patch("nestor_api.lib.docker.git", autospec=True)
-    @patch("nestor_api.lib.docker.config", autospec=True)
     @patch("nestor_api.lib.docker.io", autospec=True)
-    # pylint: disable=too-many-arguments disable=bad-continuation
-    def test_build_failure(
-        self, io_mock, config_mock, git_mock, has_docker_image_mock, logger_mock
-    ):
+    def test_build_failure(self, io_mock, git_mock, has_docker_image_mock, logger_mock):
         # Mocks
-        app_config = {"build": {"variables": {"var1": "val1", "var2": "val2"}}}
         has_docker_image_mock.return_value = False
         git_mock.get_last_tag.return_value = "1.0.0-sha-a2b3c4"
-        config_mock.get_app_config.return_value = app_config
+        git_mock.get_commit_hash_from_tag.return_value = "a2b3c4d5e6"
 
         exception = subprocess.CalledProcessError(1, "Docker build failed")
         io_mock.execute.side_effect = [exception]
 
         # Test
-        context = {"commit_hash": "a2b3c4", "repository": "/path_to/a_git_repository"}
+        repository = "/path_to/a_git_repository"
+        app_config = {}
         with self.assertRaisesRegex(Exception, "Docker build failed"):
-            docker.build("my-app", context)
+            docker.build("my-app", repository, app_config)
 
         # Assertions
         git_mock.get_last_tag.assert_called_once_with("/path_to/a_git_repository")
+        git_mock.get_commit_hash_from_tag.assert_called_once_with(
+            "/path_to/a_git_repository", "1.0.0-sha-a2b3c4"
+        )
         has_docker_image_mock.assert_called_once_with("my-app", "1.0.0-sha-a2b3c4")
-        config_mock.get_app_config.assert_called_once_with("my-app")
         io_mock.execute.assert_called_once_with(
             "docker build"
             " --tag my-app:1.0.0-sha-a2b3c4"
-            " --build-arg var1=val1"
-            " --build-arg var2=val2"
-            " --build-arg COMMIT_HASH=a2b3c4"
+            " --build-arg COMMIT_HASH=a2b3c4d5e6"
             " /path_to/a_git_repository"
         )
         logger_mock.error.assert_called_once_with(
@@ -116,46 +117,40 @@ class TestDockerLib(TestCase):
         io_mock.execute.assert_called_once_with("docker images my-app:my-tag --quiet")
         self.assertFalse(has_image)
 
+    @patch("nestor_api.lib.docker.has_docker_image", autospec=True)
     @patch("nestor_api.lib.docker.io", autospec=True)
-    @patch("nestor_api.lib.docker.git", autospec=True)
-    @patch("nestor_api.lib.docker.config", autospec=True)
-    def test_push_no_image(self, config_mock, git_mock, io_mock):
+    def test_push_no_image(self, io_mock, has_docker_image_mock):
         # Mocks
-        config_mock.get_app_config.return_value = {
-            "docker": {"registry": {"organization": "my-organization"}}
-        }
-        git_mock.get_last_tag.return_value = "1.0.0-sha-a2b3c4"
-        io_mock.execute.return_value = ""
+        has_docker_image_mock.return_value = False
 
         # Test
+        app_config = {}
+
         with self.assertRaisesRegex(RuntimeError, "Docker image not available"):
-            docker.push("my-app", "/path_to/a_git_repository")
+            docker.push("my-app", "1.0.0-sha-a2b3c4", app_config)
 
         # Assertions
-        config_mock.get_app_config.assert_called_once_with("my-app")
-        git_mock.get_last_tag.assert_called_once_with("/path_to/a_git_repository")
-        io_mock.execute.assert_called_once_with("docker images my-app:1.0.0-sha-a2b3c4 --quiet")
+        has_docker_image_mock.assert_called_once_with("my-app", "1.0.0-sha-a2b3c4")
+        io_mock.execute.assert_not_called()
 
+    @patch("nestor_api.lib.docker.has_docker_image", autospec=True)
     @patch("nestor_api.lib.docker.io", autospec=True)
-    @patch("nestor_api.lib.docker.git", autospec=True)
-    @patch("nestor_api.lib.docker.config", autospec=True)
-    def test_push(self, config_mock, git_mock, io_mock):
+    def test_push(self, io_mock, has_docker_image_mock):
         # Mocks
-        config_mock.get_app_config.return_value = {
-            "docker": {"registry": {"organization": "my-organization"}}
-        }
-        git_mock.get_last_tag.return_value = "1.0.0-sha-a2b3c4"
+        has_docker_image_mock.return_value = True
         io_mock.execute.side_effect = ["001122334455", "", ""]
 
         # Test
-        docker.push("my-app", "/path_to/a_git_repository")
+        app_config = {
+            "docker": {"registries": {"docker.com": [{"organization": "my-organization"}]}}
+        }
+
+        docker.push("my-app", "1.0.0-sha-a2b3c4", app_config)
 
         # Assertions
-        config_mock.get_app_config.assert_called_once_with("my-app")
-        git_mock.get_last_tag.assert_called_once_with("/path_to/a_git_repository")
+        has_docker_image_mock.assert_called_once_with("my-app", "1.0.0-sha-a2b3c4")
         io_mock.execute.assert_has_calls(
             [
-                call("docker images my-app:1.0.0-sha-a2b3c4 --quiet"),
                 call("docker tag my-app:1.0.0-sha-a2b3c4 my-organization/my-app:1.0.0-sha-a2b3c4"),
                 call("docker push my-organization/my-app:1.0.0-sha-a2b3c4"),
             ]

--- a/tests/lib/test_git.py
+++ b/tests/lib/test_git.py
@@ -48,7 +48,7 @@ class TestGitLibrary:
         assert repository_dir == "/fixtures-nestor-work/my-app-11111111111111"
 
     def test_get_last_commit_hash(self, io_mock):
-        io_mock.execute.return_value = "1ab2c3d\n"
+        io_mock.execute.return_value = "1ab2c3d"
 
         last_commit_hash = git.get_last_commit_hash("/path_to/a_git_repository")
 
@@ -58,7 +58,7 @@ class TestGitLibrary:
         )
 
     def test_get_last_tag(self, io_mock):
-        io_mock.execute.return_value = "1.0.0-sha-a2b3c4\n"
+        io_mock.execute.return_value = "1.0.0-sha-a2b3c4"
 
         last_tag = git.get_last_tag("/path_to/a_git_repository")
 
@@ -68,7 +68,7 @@ class TestGitLibrary:
         )
 
     def test_get_commit_hash_from_tag(self, io_mock):
-        io_mock.execute.return_value = "a2b3c4d5e6f7g8h9\n"
+        io_mock.execute.return_value = "a2b3c4d5e6f7g8h9"
 
         commit_hash = git.get_commit_hash_from_tag("/path_to/a_git_repository", "1.0.0-sha-a2b3c4")
 
@@ -78,7 +78,7 @@ class TestGitLibrary:
         )
 
     def test_get_remote_url_with_default_remote_name(self, io_mock):
-        io_mock.execute.return_value = "git@github.com:org/repo.git\n"
+        io_mock.execute.return_value = "git@github.com:org/repo.git"
 
         remote_url = git.get_remote_url("/path_to/a_git_repository")
 
@@ -88,7 +88,7 @@ class TestGitLibrary:
         )
 
     def test_get_remote_url_with_remote_name(self, io_mock):
-        io_mock.execute.return_value = "git@github.com:org/repo.git\n"
+        io_mock.execute.return_value = "git@github.com:org/repo.git"
 
         remote_url = git.get_remote_url("/path_to/a_git_repository", "custom_remote_name")
 

--- a/tests/lib/test_io.py
+++ b/tests/lib/test_io.py
@@ -47,8 +47,11 @@ class TestIoLib(TestCase):
 
     @patch("nestor_api.lib.io.subprocess.run", autospec=True)
     def test_execute(self, subprocess_run_mock):
-        io.execute("a command with --arg1 arg-value")
+        subprocess_run_mock.return_value.stdout.decode.return_value = "some output\n"
 
+        output = io.execute("a command with --arg1 arg-value")
+
+        self.assertEqual(output, "some output")
         subprocess_run_mock.assert_called_with(
             ["a", "command", "with", "--arg1", "arg-value"],
             check=True,

--- a/tests/lib/test_io.py
+++ b/tests/lib/test_io.py
@@ -1,4 +1,5 @@
 import errno
+import subprocess
 from unittest import TestCase
 from unittest.mock import mock_open, patch
 
@@ -49,7 +50,11 @@ class TestIoLib(TestCase):
         io.execute("a command with --arg1 arg-value")
 
         subprocess_run_mock.assert_called_with(
-            ["a", "command", "with", "--arg1", "arg-value"], check=True, cwd=None, stdout=-1
+            ["a", "command", "with", "--arg1", "arg-value"],
+            check=True,
+            cwd=None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
         )
 
     @patch("nestor_api.lib.io.subprocess.run", autospec=True)

--- a/tests/utils/test_dict.py
+++ b/tests/utils/test_dict.py
@@ -1,5 +1,3 @@
-# pylint: disable=missing-class-docstring disable=missing-function-docstring disable=missing-module-docstring
-
 from unittest import TestCase
 
 import nestor_api.utils.dict as dict_utils

--- a/validator/schemas/application.py
+++ b/validator/schemas/application.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 """The application schema configuration managed by Nestor"""
 
 APPLICATION_SCHEMA = {

--- a/validator/schemas/project.py
+++ b/validator/schemas/project.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 """The project schema managed by Nestor"""
 
 PROJECT_SCHEMA = {

--- a/validator/schemas/schema.py
+++ b/validator/schemas/schema.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 """Schemas class to validate the Nestor configurations"""
 
 from validator.schemas.application import APPLICATION_SCHEMA

--- a/validator/schemas/specs.py
+++ b/validator/schemas/specs.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 """Schemas managed by Nestor"""
 
 SPECS = {


### PR DESCRIPTION
In this PR, I changed the way we used to work with the app's configuration retrieval to have it passed by argument instead of having the call made everywhere.

This will be especially impacting as we will be using a safe copy of the configuration later on and not have every concurrent requests work on the same one.

> Note: it should be easier to read commit by commit, I encourage you to do so 😉 