### PR TITLE
Add read/write and yaml export to io library

### DIFF
--- a/nestor_api/lib/config.py
+++ b/nestor_api/lib/config.py
@@ -34,7 +34,7 @@ def get_app_config(app_name: str, config_path: str = Configuration.get_config_pa
     if not io.exists(app_config_path):
         raise AppConfigurationNotFoundError(app_name)
 
-    app_config = io.from_yaml(app_config_path)
+    app_config = io.read_yaml(app_config_path)
     project_config = get_project_config(config_path)
 
     config = dict_utils.deep_merge(project_config, app_config)
@@ -51,7 +51,7 @@ def get_project_config(config_path: str = Configuration.get_config_path()) -> di
     if not io.exists(project_config_path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), project_config_path)
 
-    project_config = io.from_yaml(project_config_path)
+    project_config = io.read_yaml(project_config_path)
 
     return _resolve_variables_deep(project_config)
 

--- a/nestor_api/lib/io.py
+++ b/nestor_api/lib/io.py
@@ -1,19 +1,19 @@
 """I/O library"""
-from datetime import datetime
 import errno
 import math
 import os
-from pathlib import Path
-from random import random
 import shutil
 import subprocess
+from datetime import datetime
+from pathlib import Path
+from random import random
 
 import yaml
 
 from nestor_api.config.config import Configuration
 
 
-def copy(source, destination):
+def copy(source: str, destination: str) -> None:
     """Copy file or directory with its content from source to destination"""
     try:
         shutil.copytree(source, destination)
@@ -24,7 +24,7 @@ def copy(source, destination):
             raise
 
 
-def create_temporary_directory(directory_prefix=""):
+def create_temporary_directory(directory_prefix: str = "") -> str:
     """Creates a temporary directory with an optional prefix"""
     tmp_directory_path = get_temporary_directory_path(directory_prefix)
 
@@ -34,12 +34,12 @@ def create_temporary_directory(directory_prefix=""):
     return tmp_directory_path
 
 
-def ensure_dir(directory_path):
+def ensure_dir(directory_path: str) -> None:
     """Ensures that a directory exists, else creates it"""
     Path(directory_path).mkdir(parents=True, exist_ok=True)
 
 
-def execute(command: str, cwd=None):
+def execute(command: str, cwd: str = None) -> str:
     """Executes a command and returns the stdout from it"""
     result = subprocess.run(
         command.split(), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=True, cwd=cwd,
@@ -47,12 +47,12 @@ def execute(command: str, cwd=None):
     return result.stdout.decode("utf-8").rstrip()
 
 
-def exists(file_path):
+def exists(file_path: str) -> bool:
     """Checks if a file exists"""
     return Path(file_path).exists()
 
 
-def from_yaml(file_path):
+def from_yaml(file_path: str) -> dict:
     """Returns a dictionary from yaml file path"""
     with open(file_path, "r") as file_data:
         yaml_data = file_data.read()
@@ -60,12 +60,12 @@ def from_yaml(file_path):
     return yaml.safe_load(yaml_data)
 
 
-def get_pristine_path(pristine_path_name):
+def get_pristine_path(pristine_path_name: str) -> str:
     """Returns the pristine path"""
     return os.path.join(Configuration.get_pristine_path(), pristine_path_name)
 
 
-def create_temporary_copy(directory_path, target_directory_prefix=""):
+def create_temporary_copy(directory_path: str, target_directory_prefix: str = "") -> str:
     """Creates a copy of a directory in a temporary directory and returns its path"""
     copy_path = get_temporary_directory_path(target_directory_prefix)
     copy(directory_path, copy_path)
@@ -73,7 +73,7 @@ def create_temporary_copy(directory_path, target_directory_prefix=""):
     return copy_path
 
 
-def get_temporary_directory_path(prefix=""):
+def get_temporary_directory_path(prefix: str = "") -> str:
     """Returns a temporary directory path with an optional prefix"""
     random_num = math.floor(random() * 1e9)
     random_str = "{:09d}".format(random_num)
@@ -86,12 +86,24 @@ def get_temporary_directory_path(prefix=""):
     return get_working_path(tmp_directory_name)
 
 
-def get_working_path(working_path_name):
+def get_working_path(working_path_name: str) -> str:
     """Returns the working path"""
     return os.path.join(Configuration.get_working_path(), working_path_name)
 
 
-def remove(file_path):
+def to_yaml(data: dict) -> str:
+    """Converts a dictionary into a valid yaml string"""
+    return yaml.safe_dump(data)
+
+
+def read(file_path: str) -> str:
+    """Read the file content at the given path"""
+    with open(file_path, "r") as file:
+        file_content = file.read()
+    return file_content
+
+
+def remove(file_path: str) -> None:
     """Remove a file or a directory with its content"""
     try:
         shutil.rmtree(file_path)
@@ -100,3 +112,9 @@ def remove(file_path):
             os.remove(file_path)
         else:
             raise
+
+
+def write(file_path: str, content: str) -> None:
+    """ Write the string content into the file at the given path"""
+    with open(file_path, "w") as file:
+        file.write(content)

--- a/nestor_api/lib/io.py
+++ b/nestor_api/lib/io.py
@@ -1,16 +1,21 @@
 """I/O library"""
+from datetime import datetime
 import errno
 import math
 import os
-import shutil
-import subprocess
-from datetime import datetime
 from pathlib import Path
 from random import random
+import shutil
+import subprocess
 
 import yaml
 
 from nestor_api.config.config import Configuration
+
+
+def convert_to_yaml(data: dict) -> str:
+    """Converts a dictionary into a valid yaml string"""
+    return yaml.safe_dump(data)
 
 
 def copy(source: str, destination: str) -> None:
@@ -52,14 +57,6 @@ def exists(file_path: str) -> bool:
     return Path(file_path).exists()
 
 
-def from_yaml(file_path: str) -> dict:
-    """Returns a dictionary from yaml file path"""
-    with open(file_path, "r") as file_data:
-        yaml_data = file_data.read()
-
-    return yaml.safe_load(yaml_data)
-
-
 def get_pristine_path(pristine_path_name: str) -> str:
     """Returns the pristine path"""
     return os.path.join(Configuration.get_pristine_path(), pristine_path_name)
@@ -91,16 +88,19 @@ def get_working_path(working_path_name: str) -> str:
     return os.path.join(Configuration.get_working_path(), working_path_name)
 
 
-def to_yaml(data: dict) -> str:
-    """Converts a dictionary into a valid yaml string"""
-    return yaml.safe_dump(data)
-
-
 def read(file_path: str) -> str:
     """Read the file content at the given path"""
     with open(file_path, "r") as file:
         file_content = file.read()
     return file_content
+
+
+def read_yaml(file_path: str) -> dict:
+    """Returns a dictionary from yaml file path"""
+    with open(file_path, "r") as file_data:
+        yaml_data = file_data.read()
+
+    return yaml.safe_load(yaml_data)
 
 
 def remove(file_path: str) -> None:

--- a/tests/__fixtures__/io/sample.txt
+++ b/tests/__fixtures__/io/sample.txt
@@ -1,0 +1,1 @@
+sample file

--- a/tests/lib/test_config.py
+++ b/tests/lib/test_config.py
@@ -36,7 +36,7 @@ class TestConfigLibrary(unittest.TestCase):
         # Mocks
         configuration_mock.get_config_app_folder.return_value = "apps"
         io_mock.exists.return_value = True
-        io_mock.from_yaml.return_value = {
+        io_mock.read_yaml.return_value = {
             "sub_domain": "backoffice",
             "variables": {
                 "ope": {"VARIABLE_OPE_2": "ope_2_override", "VARIABLE_OPE_3": "ope_3"},
@@ -56,7 +56,7 @@ class TestConfigLibrary(unittest.TestCase):
 
         # Assertions
         io_mock.exists.assert_called_once_with("tests/__fixtures__/config/apps/backoffice.yaml")
-        io_mock.from_yaml.assert_called_once_with("tests/__fixtures__/config/apps/backoffice.yaml")
+        io_mock.read_yaml.assert_called_once_with("tests/__fixtures__/config/apps/backoffice.yaml")
         get_project_config_mock.assert_called_once()
         self.assertEqual(
             app_config,
@@ -93,7 +93,7 @@ class TestConfigLibrary(unittest.TestCase):
         # Mocks
         configuration_mock.get_config_project_filename.return_value = "project.yaml"
         io_mock.exists.return_value = True
-        io_mock.from_yaml.return_value = {
+        io_mock.read_yaml.return_value = {
             "domain": "website.com",
             "variables": {
                 "ope": {"VARIABLE_OPE_1": "ope_1", "VARIABLE_OPE_2": "ope_2"},
@@ -106,7 +106,7 @@ class TestConfigLibrary(unittest.TestCase):
 
         # Assertions
         io_mock.exists.assert_called_once_with("tests/__fixtures__/config/project.yaml")
-        io_mock.from_yaml.assert_called_once_with("tests/__fixtures__/config/project.yaml")
+        io_mock.read_yaml.assert_called_once_with("tests/__fixtures__/config/project.yaml")
         self.assertEqual(
             environment_config,
             {


### PR DESCRIPTION
Add function required for kubernetes library in order to read/write configuration file and deploy using `kubectl apply`.

_Note:_ I also took the time to add missing typings to already existing function (both params and return value)