### PR TITLE
Applications and cronjobs getters for an application configuration

### DIFF
--- a/nestor_api/lib/config.py
+++ b/nestor_api/lib/config.py
@@ -46,6 +46,16 @@ def get_app_config(app_name: str, config_path: str = Configuration.get_config_pa
     return _resolve_variables_deep(config)
 
 
+def get_cronjobs(app_config: dict) -> list:
+    """Get cronjobs processes"""
+    return [process for process in app_config["processes"] if process["is_cronjob"]]
+
+
+def get_processes(app_config: dict) -> list:
+    """Get processes (not cronjobs)"""
+    return [process for process in app_config["processes"] if not process["is_cronjob"]]
+
+
 def get_project_config(config_path: str = Configuration.get_config_path()) -> dict:
     """Load the global configuration of the project"""
     project_config_path = os.path.join(config_path, Configuration.get_config_project_filename())

--- a/tests/lib/test_config.py
+++ b/tests/lib/test_config.py
@@ -88,6 +88,42 @@ class TestConfigLibrary(unittest.TestCase):
 
         self.assertEqual("Configuration file not found for app: some-app", str(context.exception))
 
+    def test_get_processes(self, _io_mock):
+        app_config = {
+            "name": "my-app",
+            "processes": [
+                {"name": "web", "start_command": "./web", "is_cronjob": False,},
+                {"name": "cleaner", "start_command": "./clean", "is_cronjob": True,},
+                {"name": "worker", "start_command": "./worker", "is_cronjob": False,},
+            ],
+        }
+
+        applications = config.get_processes(app_config)
+
+        self.assertEqual(
+            applications,
+            [
+                {"name": "web", "start_command": "./web", "is_cronjob": False,},
+                {"name": "worker", "start_command": "./worker", "is_cronjob": False,},
+            ],
+        )
+
+    def test_get_cronjobs(self, _io_mock):
+        app_config = {
+            "name": "my-app",
+            "processes": [
+                {"name": "web", "start_command": "./web", "is_cronjob": False,},
+                {"name": "cleaner", "start_command": "./clean", "is_cronjob": True,},
+                {"name": "worker", "start_command": "./worker", "is_cronjob": False,},
+            ],
+        }
+
+        cronjobs = config.get_cronjobs(app_config)
+
+        self.assertEqual(
+            cronjobs, [{"name": "cleaner", "start_command": "./clean", "is_cronjob": True,}]
+        )
+
     @patch("nestor_api.lib.config.Configuration", autospec=True)
     def test_get_project_config(self, configuration_mock, io_mock):
         # Mocks


### PR DESCRIPTION
Add the ability to retrieve `applications` and `cronjobs` for an application configuration in order to create one deployment for each process.