### PR TITLE
Fix stuck coverage on CI (downgrade to actions/checkout@v1)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,27 +10,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pipenv
-        pipenv sync --dev
-        pipenv run pip list
-    - name: Lint
-      run: pipenv run make lint
-    - name: Type checking
-      run: pipenv run make mypy
-    - name: Tests
-      run: pipenv run make test
-    - name: Coverage check
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage/coverage.xml
-        flags: unittests
-        name: codecov-upload
-        fail_ci_if_error: true
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+          pipenv sync --dev
+          pipenv run pip list
+      - name: Lint
+        run: pipenv run make lint
+      - name: Type checking
+        run: pipenv run make mypy
+      - name: Tests
+        run: pipenv run make test
+      - name: Coverage check
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage/coverage.xml
+          flags: unittests
+          name: codecov-upload
+          fail_ci_if_error: true


### PR DESCRIPTION
There seems to be an issue with github actions/checkout@v2.

See : 
- https://community.codecov.io/t/codecov-status-stuck-at-waiting-for-status-to-be-reported-on-github/341/41
- https://github.com/actions/checkout/issues/237