### PR TITLE
Report errors when validation fails

### DIFF
--- a/tests/__fixtures__/validator/apps_with_errors/app.yaml
+++ b/tests/__fixtures__/validator/apps_with_errors/app.yaml
@@ -1,0 +1,12 @@
+app: app_test
+app: some_application
+is_enabled: true
+git:
+  origin: git@github.com:your_company/app_test.git
+teams:
+  - platform
+variables:
+  app: {}
+  ope:
+    test_date: '2020-07-02'
+    test_datetime: '2020-07-02T10:13:00.000Z'

--- a/tests/config_validator/test_validate.py
+++ b/tests/config_validator/test_validate.py
@@ -119,10 +119,10 @@ class TestValidateLibrary(unittest.TestCase):
     @patch("validator.validate.build_apps_path")
     @patch("validator.config.config.Configuration.get_validation_target")
     def test_validate_apps_with_errors(self, get_validation_target_mock, build_apps_path_mock):
-        real_config_fixture_path = Path(
+        config_fixture_path = Path(
             os.path.dirname(__file__), "..", "__fixtures__", "validator", "apps_with_errors"
         ).resolve()
-        build_apps_path_mock.return_value = real_config_fixture_path
+        build_apps_path_mock.return_value = config_fixture_path
         get_validation_target_mock.return_value = "APPLICATIONS"
 
         expected_error = "Found a duplicate key: app"

--- a/validator/validate.py
+++ b/validator/validate.py
@@ -54,7 +54,7 @@ def validate_file(file_path: str, schema: dict) -> str:
     return jsonschema.validate(yaml_file, schema)
 
 
-def validate_deployment_files():
+def validate_deployment_files() -> list:
     """Main validate function
 
     This function executes a specific validation configured with NESTOR_VALIDATION_TARGET

--- a/validator/validate.py
+++ b/validator/validate.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 import jsonschema  # type: ignore
+from yaml.constructor import ConstructorError
 
 from validator.config.config import Configuration, SupportedValidations
 from validator.errors.errors import InvalidTargetPathError
@@ -62,6 +63,9 @@ def validate_deployment_files():
     Raises:
         Exception: If the configuration path has not been configured.
         Exception: If the configuration path does not exist
+
+    Returns:
+        list: A list with errors, if empty there were no errors validating the files
     """
     apps_path = build_apps_path()
     if not Path(apps_path).exists():
@@ -69,6 +73,7 @@ def validate_deployment_files():
             f"{apps_path} does not look like a valid configuration path. Verify the path exists"
         )
 
+    errors = []
     validation_target = Configuration.get_validation_target()
 
     if validation_target == str(SupportedValidations.APPLICATIONS):
@@ -85,15 +90,22 @@ def validate_deployment_files():
 
         for file in files_in_dir:
             application_config_file_path = os.path.join(apps_path, file)
-            validate_file(application_config_file_path, SCHEMAS[validation_target])
+            try:
+                validate_file(application_config_file_path, SCHEMAS[validation_target])
+            except ConstructorError as validation_error:
+                errors.append(validation_error)
 
     elif validation_target == str(SupportedValidations.PROJECTS):
         # Validate project.yaml
         project_config_file_path = build_project_conf_path()
-        validate_file(project_config_file_path, SCHEMAS[validation_target])
-
+        try:
+            validate_file(project_config_file_path, SCHEMAS[validation_target])
+        except ConstructorError as validation_error:
+            errors.append(validation_error)
     else:
         raise Exception(
             "There is no configuration to be validated. "
             + "Be sure to define a valid NESTOR_VALIDATION_TARGET"
         )
+
+    return errors


### PR DESCRIPTION
This PR aims to provide useful feedback to nestor users when they are configuring apps or projects. A list of errors will be provided if there were issues like duplicate keys.

To the contrary of what AJV does in NodeJS, jsonschema only provides the first error that it's found while validating a file against a schema, so at most we will be only able to provide one error .