### PR TITLE
Create simple logger with basicConfig

### DIFF
--- a/nestor_api/utils/logger.py
+++ b/nestor_api/utils/logger.py
@@ -1,21 +1,66 @@
 """A simple logger implementation awaiting for proper implementation"""
 
+import json
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s-%(asctime)s: %(message)s",
+    datefmt="%d-%b-%y %H:%M:%S",
+)
+
 
 class Logger:
-    """A fake logger module to be able to collect logs later on"""
+    """A logger module"""
 
     @staticmethod
-    def debug(context: dict, message: str):
-        """Produce a log with debug level"""
+    def debug(context=None, message=""):
+        """Produce a log with debug level
+
+        Args:
+            context (dict): An object with relevant information for debugging
+            message (str): Additional message for context/debugging
+        """
+        if context is None:
+            logging.debug(message)
+        else:
+            logging.debug("%s %s", message, json.dumps(context))
 
     @staticmethod
-    def error(context: dict, message: str):
-        """Produce a log with error level"""
+    def info(context=None, message=""):
+        """Produce a log with info level
+
+        Args:
+            context (dict): An object with relevant information for debugging
+            message (str): Additional message for context/debugging
+        """
+        if context is None:
+            logging.info(message)
+        else:
+            logging.info("%s %s", message, json.dumps(context))
 
     @staticmethod
-    def info(context: dict, message: str):
-        """Produce a log with info level"""
+    def warn(context=None, message=""):
+        """Produce a log with warn level
+
+        Args:
+            context (dict): An object with relevant information for debugging
+            message (str): Additional message for context/debugging
+        """
+        if context is None:
+            logging.warning(message)
+        else:
+            logging.warning("%s %s", message, json.dumps(context))
 
     @staticmethod
-    def warn(context: dict, message: str):
-        """Produce a log with warn level"""
+    def error(context=None, message=""):
+        """Produce a log with error level
+
+        Args:
+            context (dict): An object with relevant information for debugging
+            message (str): Additional message for context/debugging
+        """
+        if context is None:
+            logging.error(message, exc_info=True)
+        else:
+            logging.error("%s %s", message, json.dumps(context), exc_info=True)

--- a/nestor_api/utils/logger.py
+++ b/nestor_api/utils/logger.py
@@ -1,4 +1,4 @@
-"""A simple logger implementation awaiting for proper implementation"""
+"""A simple logger implementation using native logging from Python"""
 
 import json
 import logging
@@ -11,10 +11,10 @@ logging.basicConfig(
 
 
 class Logger:
-    """A logger module"""
+    """A logger module with contextual information"""
 
     @staticmethod
-    def debug(context=None, message=""):
+    def debug(context=None, message="") -> None:
         """Produce a log with debug level
 
         Args:
@@ -27,7 +27,7 @@ class Logger:
             logging.debug("%s %s", message, json.dumps(context))
 
     @staticmethod
-    def info(context=None, message=""):
+    def info(context=None, message="") -> None:
         """Produce a log with info level
 
         Args:
@@ -40,7 +40,7 @@ class Logger:
             logging.info("%s %s", message, json.dumps(context))
 
     @staticmethod
-    def warn(context=None, message=""):
+    def warn(context=None, message="") -> None:
         """Produce a log with warn level
 
         Args:
@@ -53,7 +53,7 @@ class Logger:
             logging.warning("%s %s", message, json.dumps(context))
 
     @staticmethod
-    def error(context=None, message=""):
+    def error(context=None, message="") -> None:
         """Produce a log with error level
 
         Args:

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -1,0 +1,50 @@
+"""Unit test for logger class"""
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from nestor_api.utils.logger import Logger
+
+
+class TestLogger(TestCase):
+    @patch("nestor_api.utils.logger.logging", autospec=True)
+    def test_logger_debug(self, logging_mock):
+        Logger.debug({"user_id": 1234}, "Found user")
+        logging_mock.debug.assert_called_once_with("%s %s", "Found user", '{"user_id": 1234}')
+
+    @patch("nestor_api.utils.logger.logging", autospec=True)
+    def test_logger_debug_with_no_context(self, logging_mock):
+        Logger.debug(message="Found user")
+        logging_mock.debug.assert_called_once_with("Found user")
+
+    @patch("nestor_api.utils.logger.logging", autospec=True)
+    def test_logger_info(self, logging_mock):
+        Logger.info({"user_id": 1234}, "Found user")
+        logging_mock.info.assert_called_once_with("%s %s", "Found user", '{"user_id": 1234}')
+
+    @patch("nestor_api.utils.logger.logging", autospec=True)
+    def test_logger_info_with_no_context(self, logging_mock):
+        Logger.info(message="Found user")
+        logging_mock.info.assert_called_once_with("Found user")
+
+    @patch("nestor_api.utils.logger.logging", autospec=True)
+    def test_logger_warn(self, logging_mock):
+        Logger.warn({"user_id": 1234}, "Found user")
+        logging_mock.warning.assert_called_once_with("%s %s", "Found user", '{"user_id": 1234}')
+
+    @patch("nestor_api.utils.logger.logging", autospec=True)
+    def test_logger_warn_with_no_context(self, logging_mock):
+        Logger.warn(message="Found user")
+        logging_mock.warning.assert_called_once_with("Found user")
+
+    @patch("nestor_api.utils.logger.logging", autospec=True)
+    def test_logger_error(self, logging_mock):
+        Logger.error({"user_id": 1234}, "Found user")
+        logging_mock.error.assert_called_once_with(
+            "%s %s", "Found user", '{"user_id": 1234}', exc_info=True
+        )
+
+    @patch("nestor_api.utils.logger.logging", autospec=True)
+    def test_logger_error_with_no_context(self, logging_mock):
+        Logger.error(message="Found user")
+        logging_mock.error.assert_called_once_with("Found user", exc_info=True)


### PR DESCRIPTION
This PR adds the implementation of a very simple logger module. 

It internally wraps the library `logging` from Python. It's up to discussion whether we add more features to the logger module such as:

- Collection of logs into files and a periodical rotation (daily, weekly, etc)
- Add more levels such as: `critical` used in some projects and already existing in the logging library
- Overriding the basic config?


### Usage with context

```py
Logger.info(message="hello", context={"person": "guillaume"})
```

```sh
INFO-22-Jul-20 16:06:46: hello {"person": "guillaume"}
```

### Usage without context

```py
Logger.info("hello")
```

```sh
INFO-22-Jul-20 16:06:46: hello
```

