### PR TITLE
Add new library functions needed for the deployment_api

### DIFF
--- a/nestor_api/lib/config.py
+++ b/nestor_api/lib/config.py
@@ -68,6 +68,18 @@ def get_project_config(config_path: str = Configuration.get_config_path()) -> di
     return _resolve_variables_deep(project_config)
 
 
+def get_deployments_configs(project_config: dict) -> list:
+    """Get the deployments configurations from the project configuration."""
+    deployments_configs = []
+    for deployment in project_config["deployments"]:
+        config = dict_utils.deep_merge(project_config, deployment)
+        del config["deployments"]
+        config = _resolve_variables_deep(config)
+        deployments_configs.append(config)
+
+    return deployments_configs
+
+
 def _resolve_variable(template: str, variables: dict, path: str) -> str:
     final_value = template
 

--- a/nestor_api/lib/config.py
+++ b/nestor_api/lib/config.py
@@ -68,16 +68,16 @@ def get_project_config(config_path: str = Configuration.get_config_path()) -> di
     return _resolve_variables_deep(project_config)
 
 
-def get_deployments_configs(project_config: dict) -> list:
+def get_deployments(project_config: dict) -> list:
     """Get the deployments configurations from the project configuration."""
-    deployments_configs = []
+    deployments = []
     for deployment in project_config["deployments"]:
         config = dict_utils.deep_merge(project_config, deployment)
         del config["deployments"]
         config = _resolve_variables_deep(config)
-        deployments_configs.append(config)
+        deployments.append(config)
 
-    return deployments_configs
+    return deployments
 
 
 def _resolve_variable(template: str, variables: dict, path: str) -> str:

--- a/nestor_api/lib/docker.py
+++ b/nestor_api/lib/docker.py
@@ -52,6 +52,11 @@ def get_registry_image_tag(app_name: str, image_tag: str, registry: dict) -> str
     return f"{registry['organization']}/{app_name}:{image_tag}"
 
 
+def get_version_from_image_tag(image_tag: str) -> str:
+    """Returns the image version from an image tag"""
+    return image_tag.split(":")[1]
+
+
 def push(app_name: str, image_tag: str, app_config: dict) -> None:
     """Push an image to the configured docker registry"""
     if not has_docker_image(app_name, image_tag):

--- a/nestor_api/lib/git.py
+++ b/nestor_api/lib/git.py
@@ -31,6 +31,32 @@ def create_working_repository(app_name: str, git_url: str) -> str:
     return repository_dir
 
 
+def get_commit_hash_from_tag(repository_dir: str, tag_name: str) -> str:
+    """Returns the commit hash associated to the given tag"""
+    return io.execute(f"git rev-list -1 {tag_name}", repository_dir)
+
+
+def get_commits_between_tags(repository_dir: str, tag_old: str, tag_new: str) -> list:
+    """Get the commits between two tags (ordered with the newest first)."""
+    output = io.execute(
+        f"git log --oneline --no-decorate refs/tags/{tag_old}..refs/tags/{tag_new}", repository_dir
+    )
+
+    commits = []
+    for line in output.splitlines():
+        commit = {}
+        split_idx = line.find(" ")
+        commit["hash"] = line[:split_idx]
+        commit["message"] = line[split_idx + 1 :]
+        commits.append(commit)
+    return commits
+
+
+def get_last_commit_hash(repository_dir: str, reference: str = "HEAD") -> str:
+    """Retrieves the last commit hash of a repository (locally)"""
+    return io.execute(f"git rev-parse --short {reference}", repository_dir)
+
+
 def get_last_tag(repository_dir: str) -> str:
     """Retrieves the last tag of a repository (locally)"""
     return io.execute("git describe --always --abbrev=0", repository_dir)
@@ -39,16 +65,6 @@ def get_last_tag(repository_dir: str) -> str:
 def get_remote_url(repository_dir: str, remote_name: str = "origin") -> str:
     """Retrieves the remote url of a repository"""
     return io.execute(f"git remote get-url {remote_name}", repository_dir)
-
-
-def get_last_commit_hash(repository_dir: str, reference: str = "HEAD") -> str:
-    """Retrieves the last commit hash of a repository (locally)"""
-    return io.execute(f"git rev-parse --short {reference}", repository_dir)
-
-
-def get_commit_hash_from_tag(repository_dir: str, tag_name: str) -> str:
-    """Returns the commit hash associated to the given tag"""
-    return io.execute(f"git rev-list -1 {tag_name}", repository_dir)
 
 
 def push(repository_dir: str, branch_name: str = "HEAD") -> None:

--- a/nestor_api/lib/io.py
+++ b/nestor_api/lib/io.py
@@ -8,14 +8,7 @@ from random import random
 import shutil
 import subprocess
 
-import yaml
-
 from nestor_api.config.config import Configuration
-
-
-def convert_to_yaml(data: dict) -> str:
-    """Converts a dictionary into a valid yaml string"""
-    return yaml.safe_dump(data)
 
 
 def copy(source: str, destination: str) -> None:

--- a/nestor_api/utils/dict.py
+++ b/nestor_api/utils/dict.py
@@ -3,7 +3,7 @@
 import copy
 
 
-def deep_merge(destination: dict, source: dict) -> dict:
+def deep_merge(destination: dict, source: dict, concat_lists: bool = False) -> dict:
     """Recursively add all keys from `source` into `destination`.
 
     Example:
@@ -17,6 +17,8 @@ def deep_merge(destination: dict, source: dict) -> dict:
         for key in src:
             if isinstance(dest.get(key), dict) and isinstance(src[key], dict):
                 dest[key] = _deep_merge_rec(dest[key], src[key])
+            elif isinstance(dest.get(key), list) and isinstance(src[key], list) and concat_lists:
+                dest[key].extend(src[key])
             else:
                 dest[key] = src[key]
         return dest

--- a/nestor_api/utils/list.py
+++ b/nestor_api/utils/list.py
@@ -1,0 +1,19 @@
+"""List utilities."""
+
+from typing import Any, Callable, Optional
+
+
+def flatten(double_list: list) -> list:
+    """Flatten a list of list into a simple list.
+
+    Example:
+       >>> flatten([[1, 2], [3, 4], [5, 6]])
+       [1, 2, 3, 4, 5, 6]
+    """
+    return [item for sublist in double_list for item in sublist]
+
+
+def find(items: list, predicate: Callable[[Any], bool]) -> Optional[Any]:
+    """Find the first item in the list matching the predicate
+    or returns `None` if no match is found."""
+    return next((item for item in items if predicate(item)), None)

--- a/tests/lib/test_config.py
+++ b/tests/lib/test_config.py
@@ -127,6 +127,34 @@ class TestConfigLibrary(unittest.TestCase):
             cronjobs, [{"name": "cleaner", "start_command": "./clean", "is_cronjob": True,}]
         )
 
+    def test_get_deployments_config(self, _io_mock):
+        project_config = {
+            "project": "my-project",
+            "spec": {"spec_1": "default_spec_1", "spec_2": "default_spec_2",},
+            "deployments": [
+                {"cluster": "cluster_1", "spec": {"spec_1": "spec_deployment_1"}},
+                {"cluster": "cluster_2", "spec": {"spec_2": "spec_deployment_2"}},
+            ],
+        }
+
+        deployments = config.get_deployments_configs(project_config)
+
+        self.assertEqual(
+            deployments,
+            [
+                {
+                    "cluster": "cluster_1",
+                    "project": "my-project",
+                    "spec": {"spec_1": "spec_deployment_1", "spec_2": "default_spec_2"},
+                },
+                {
+                    "cluster": "cluster_2",
+                    "project": "my-project",
+                    "spec": {"spec_1": "default_spec_1", "spec_2": "spec_deployment_2"},
+                },
+            ],
+        )
+
     @patch("yaml_lib.read_yaml", autospec=True)
     @patch("nestor_api.lib.config.Configuration", autospec=True)
     def test_get_project_config(self, configuration_mock, read_yaml_mock, io_mock):

--- a/tests/lib/test_config.py
+++ b/tests/lib/test_config.py
@@ -127,7 +127,7 @@ class TestConfigLibrary(unittest.TestCase):
             cronjobs, [{"name": "cleaner", "start_command": "./clean", "is_cronjob": True,}]
         )
 
-    def test_get_deployments_config(self, _io_mock):
+    def test_get_deployments(self, _io_mock):
         project_config = {
             "project": "my-project",
             "spec": {"spec_1": "default_spec_1", "spec_2": "default_spec_2",},
@@ -137,7 +137,7 @@ class TestConfigLibrary(unittest.TestCase):
             ],
         }
 
-        deployments = config.get_deployments_configs(project_config)
+        deployments = config.get_deployments(project_config)
 
         self.assertEqual(
             deployments,

--- a/tests/lib/test_docker.py
+++ b/tests/lib/test_docker.py
@@ -99,6 +99,11 @@ class TestDockerLib(TestCase):
         )
         self.assertEqual(registry_image_tag, "my-organization/my-app:my-tag")
 
+    def test_get_version_from_image_tag(self):
+        image_tag = "organization/project-name:0.0.0-sha-1a2bc34d"
+        version = docker.get_version_from_image_tag(image_tag)
+        self.assertEqual(version, "0.0.0-sha-1a2bc34d")
+
     @patch("nestor_api.lib.docker.io", autospec=True)
     def test_has_docker_image_existing(self, io_mock):
         io_mock.execute.return_value = "001122334455"

--- a/tests/lib/test_git.py
+++ b/tests/lib/test_git.py
@@ -46,6 +46,28 @@ class TestGitLibrary(TestCase):
         )
         self.assertEqual(repository_dir, "/fixtures-nestor-work/my-app-11111111111111")
 
+    def test_get_commits_between_tags(self, io_mock):
+        io_mock.execute.return_value = (
+            "a1b1c1d Last known revision\n"
+            + "a2b2c2d An older revision\n"
+            + "a3b3c3d An even older revision\n"
+        )
+
+        commits = git.get_commits_between_tags("/path_to/a_git_repository", "old_tag", "new_tag")
+
+        io_mock.execute.assert_called_once_with(
+            "git log --oneline --no-decorate refs/tags/old_tag..refs/tags/new_tag",
+            "/path_to/a_git_repository",
+        )
+        self.assertEqual(
+            commits,
+            [
+                {"hash": "a1b1c1d", "message": "Last known revision"},
+                {"hash": "a2b2c2d", "message": "An older revision"},
+                {"hash": "a3b3c3d", "message": "An even older revision"},
+            ],
+        )
+
     def test_get_last_commit_hash_without_reference(self, io_mock):
         io_mock.execute.return_value = "1ab2c3d"
 

--- a/tests/lib/test_io.py
+++ b/tests/lib/test_io.py
@@ -11,21 +11,6 @@ import nestor_api.lib.io as io
 
 
 class TestIoLib(TestCase):
-    def test_convert_to_yaml(self):
-        dictionary_to_convert = {
-            "name": "John Doe",
-            "contact": {"phone": 1234567890, "mail": "john@doe.com"},
-            "items": ["items1", "items2"],
-        }
-
-        yaml = io.convert_to_yaml(dictionary_to_convert)
-
-        self.assertEqual(
-            yaml,
-            "contact:\n  mail: john@doe.com\n  phone: 1234567890\nitems:\n- "
-            "items1\n- items2\nname: John Doe\n",
-        )
-
     @patch("nestor_api.lib.io.shutil", autospec=True)
     def test_copy_single_file(self, shutil_mock):
         shutil_mock.copytree.side_effect = OSError(errno.ENOTDIR, "some reason")

--- a/tests/utils/test_dict.py
+++ b/tests/utils/test_dict.py
@@ -5,13 +5,36 @@ import nestor_api.utils.dict as dict_utils
 
 class TestDictUtil(TestCase):
     def test_deep_merge_should_correctly_merge_nested_dicts(self):
+        """Should correctly deep merge 2 dictionaries."""
         dict_a = {1: "1a", 2: {3: "3a", 4: "4a"}, 7: {8: "8a"}}
         dict_b = {2: {3: "3b", 5: "5b"}, 6: "6b", 9: {10: "10b"}}
 
         result = dict_utils.deep_merge(dict_a, dict_b)
+
         self.assertEqual(dict_a, {1: "1a", 2: {3: "3a", 4: "4a"}, 7: {8: "8a"}})
         self.assertEqual(dict_b, {2: {3: "3b", 5: "5b"}, 6: "6b", 9: {10: "10b"}})
         self.assertEqual(
-            result,
-            {1: "1a", 2: {3: "3b", 4: "4a", 5: "5b"}, 6: "6b", 7: {8: "8a"}, 9: {10: "10b"},},
+            result, {1: "1a", 2: {3: "3b", 4: "4a", 5: "5b"}, 6: "6b", 7: {8: "8a"}, 9: {10: "10b"}}
         )
+
+    def test_should_concat_lists_if_specified(self):
+        """Should concat the new list at the end of the original one."""
+        dict_a = {1: "1a", 2: {3: ["a", "b"]}}
+        dict_b = {1: "1b", 2: {3: ["c", "d"]}}
+
+        result = dict_utils.deep_merge(dict_a, dict_b, concat_lists=True)
+
+        self.assertEqual(dict_a, {1: "1a", 2: {3: ["a", "b"]}})
+        self.assertEqual(dict_b, {1: "1b", 2: {3: ["c", "d"]}})
+        self.assertEqual(result, {1: "1b", 2: {3: ["a", "b", "c", "d"]}})
+
+    def test_should_not_concat_lists_by_default(self):
+        """Should replace a list value by the new value."""
+        dict_a = {1: "1a", 2: {3: ["a", "b"]}}
+        dict_b = {1: "1b", 2: {3: ["c", "d"]}}
+
+        result = dict_utils.deep_merge(dict_a, dict_b)
+
+        self.assertEqual(dict_a, {1: "1a", 2: {3: ["a", "b"]}})
+        self.assertEqual(dict_b, {1: "1b", 2: {3: ["c", "d"]}})
+        self.assertEqual(result, {1: "1b", 2: {3: ["c", "d"]}})

--- a/tests/utils/test_list.py
+++ b/tests/utils/test_list.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+
+import nestor_api.utils.list as list_utils
+
+
+class TestListUtil(TestCase):
+    def test_flatten(self):
+        """Should correctly flatten the given list."""
+        double_list = [[1, 2], [3, 4], [5, 6]]
+
+        result = list_utils.flatten(double_list)
+
+        self.assertEqual(result, [1, 2, 3, 4, 5, 6])
+
+    def test_find_with_one_match(self):
+        """Should correctly find the match."""
+        items = [1, 3, 5, 6, 7]
+        predicate = lambda n: n % 2 == 0
+
+        result = list_utils.find(items, predicate)
+
+        self.assertEqual(result, 6)
+
+    def test_find_with_several_matches(self):
+        """Should correctly find the first match."""
+        items = [1, 3, 4, 5, 6, 7]
+        predicate = lambda n: n % 2 == 0
+
+        result = list_utils.find(items, predicate)
+
+        self.assertEqual(result, 4)
+
+    def test_find_with_no_matches(self):
+        """Should return None."""
+        items = [1, 3, 5, 7]
+        predicate = lambda n: n % 2 == 0
+
+        result = list_utils.find(items, predicate)
+
+        self.assertIsNone(result)

--- a/tests/yaml_tests/test_dump_yaml.py
+++ b/tests/yaml_tests/test_dump_yaml.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+import yaml_lib
+
+
+class TestDumpYaml(TestCase):
+    def test_convert_to_yaml(self):
+        dictionary_to_convert = {
+            "name": "John Doe",
+            "contact": {"phone": 1234567890, "mail": "john@doe.com"},
+            "items": ["items1", "items2"],
+        }
+
+        yaml = yaml_lib.convert_to_yaml(dictionary_to_convert)
+
+        self.assertEqual(
+            yaml,
+            "contact:\n  mail: john@doe.com\n  phone: 1234567890\nitems:\n- "
+            "items1\n- items2\nname: John Doe\n",
+        )

--- a/tests/yaml_tests/test_load_yaml.py
+++ b/tests/yaml_tests/test_load_yaml.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import yaml_lib
 
 
-class TestCustomYamlLoader(TestCase):
+class TestLoadYaml(TestCase):
     def test_parse_yaml(self):
         """Assert that parse_yaml can parse a valid yaml"""
         yaml_fixture_path = Path(

--- a/yaml_lib/__init__.py
+++ b/yaml_lib/__init__.py
@@ -1,3 +1,4 @@
 """Library to handle all the YAML related functions"""
 
+from .dump_yaml import convert_to_yaml
 from .load_yaml import parse_yaml, read_yaml

--- a/yaml_lib/dump_yaml.py
+++ b/yaml_lib/dump_yaml.py
@@ -1,0 +1,8 @@
+"Module encapsulating the dump methods from pyyaml."
+
+import yaml
+
+
+def convert_to_yaml(data: dict) -> str:
+    """Converts a dictionary into a valid yaml string"""
+    return yaml.safe_dump(data)


### PR DESCRIPTION
This PR adds a few functionalities to the existing `lib/` modules that will be used by the deployment_api in a later PR.

Hint: I split each new function commit-by-commit to improve the readability 🙂 