### PR TITLE
Add setters in k8s/builder

### DIFF
--- a/nestor_api/lib/k8s/builders.py
+++ b/nestor_api/lib/k8s/builders.py
@@ -1,7 +1,7 @@
 """k8s deployment file builders"""
 
 import os
-from typing import Optional
+from typing import Optional, Tuple
 
 from pybars import Compiler  # type: ignore
 
@@ -9,7 +9,12 @@ from nestor_api.config.probes import ProbesDefaultConfiguration
 from nestor_api.config.replicas import ReplicasDefaultConfiguration
 import nestor_api.lib.docker as docker
 import nestor_api.lib.io as io
+import nestor_api.utils.dict as dict_utils
+import nestor_api.utils.list as list_utils
 import yaml_lib
+
+SERVICE_PORT = 8080
+
 
 TEMPLATES = [
     "deployment",
@@ -39,53 +44,70 @@ def load_templates(templates_path: str, template_names: list) -> dict:
     }
 
 
-def get_anti_affinity_node(app_config: dict, process_name: str, templates: dict) -> Optional[dict]:
-    """Return the anti affinity for node configuration."""
-    app_name = app_config["app"]
-    is_anti_affinity_node_default_enabled = app_config["affinity"]["default"][
+def get_anti_affinity_node(
+    deployment_config: dict, process_name: str, templates: dict
+) -> Optional[dict]:
+    """Return the anti affinity for node configuration"""
+    app_name = deployment_config["app"]
+    is_anti_affinity_node_default_enabled = deployment_config["affinity"]["default"][
         "is_anti_affinity_node_enabled"
     ]
     is_anti_affinity_node_process_enabled = (
-        app_config["affinity"].get(process_name, {}).get("is_anti_affinity_node_enabled", False)
+        deployment_config["affinity"]
+        .get(process_name, {})
+        .get("is_anti_affinity_node_enabled", False)
     )
 
     anti_affinity_node = None
 
     if is_anti_affinity_node_default_enabled or is_anti_affinity_node_process_enabled:
         anti_affinity_node = yaml_lib.parse_yaml(
-            templates["anti_affinity_node"]({"app": app_name, "process": process_name}),
+            templates["anti-affinity-node"]({"app": app_name, "process": process_name}),
         )
 
     return anti_affinity_node
 
 
-def get_anti_affinity_zone(app_config: dict, process_name: str, templates: dict) -> Optional[dict]:
+def get_anti_affinity_zone(
+    deployment_config: dict, process_name: str, templates: dict
+) -> Optional[dict]:
     """Return the anti affinity for zone configuration."""
-    app_name = app_config["app"]
-    is_anti_affinity_zone_default_enabled = app_config["affinity"]["default"][
+    app_name = deployment_config["app"]
+    is_anti_affinity_zone_default_enabled = deployment_config["affinity"]["default"][
         "is_anti_affinity_zone_enabled"
     ]
     is_anti_affinity_zone_process_enabled = (
-        app_config["affinity"].get(process_name, {}).get("is_anti_affinity_zone_enabled", False)
+        deployment_config["affinity"]
+        .get(process_name, {})
+        .get("is_anti_affinity_zone_enabled", False)
     )
 
     anti_affinity_zone = None
 
     if is_anti_affinity_zone_default_enabled or is_anti_affinity_zone_process_enabled:
         anti_affinity_zone = yaml_lib.parse_yaml(
-            templates["anti_affinity_zone"]({"app": app_name, "process": process_name}),
+            templates["anti-affinity-zone"]({"app": app_name, "process": process_name}),
         )
 
     return anti_affinity_zone
 
 
-def get_image_name(app_config: dict, options: dict):
+def get_image_name(deployment_config: dict, options: dict) -> str:
     """Returns the definitive image name."""
+    image_name = deployment_config.get("docker", {}).get("image_name") or deployment_config["app"]
+
+    registry_ref = deployment_config["registry"]
+    registries = deployment_config["docker"]["registries"][registry_ref["platform"]]
+    registry = list_utils.find(registries, lambda reg: reg["id"] == registry_ref["id"])
+    if registry is None:
+        raise ValueError(f'No registry matching "{registry_ref["id"]}"')
+
     image_tag = options["branch"] if "branch" in options else options["tag"]
-    return docker.get_registry_image_tag(app_config["app"], image_tag, app_config["registry"])
+
+    return docker.get_registry_image_tag(image_name, image_tag, registry)
 
 
-def get_probes(probes_config: dict, port: int):
+def get_probes(probes_config: dict, port: int) -> dict:
     """Returns probes definition."""
     # The probes configuration can either be unique or specific for liveness and readiness,
     # If it is unique, `probes_config` contains the config for both probes
@@ -122,9 +144,9 @@ def get_probes(probes_config: dict, port: int):
     return probes
 
 
-def get_sanitized_names(app_config: dict, process_name: str):
+def get_sanitized_names(deployment_config: dict, process_name: str) -> Tuple[str, str, str]:
     """Return the names used in the Kubernetes templates: app, process name and metadata name."""
-    app = app_config["app"]
+    app = deployment_config["app"]
     sanitized_process_name = process_name.replace("_", "-").lower()
     metadata_name = f"{app}----{sanitized_process_name}"
 
@@ -148,12 +170,12 @@ def get_secret_variables(app_config: dict) -> dict:
     return formatted_secret_variables
 
 
-def get_variables(app_config: dict) -> dict:
+def get_variables(deployment_config: dict) -> dict:
     """Environment variables update to support the 2 level of definition
     - ope for operational environment variables
     - app for application level environment variables
     """
-    variables = app_config.get("variables", {})
+    variables = deployment_config.get("variables", {})
 
     app_variables = variables.get("app", {})
     ope_variables = variables.get("ope", {})
@@ -164,10 +186,44 @@ def get_variables(app_config: dict) -> dict:
     }
 
 
-def set_namespace(app_config: dict, resources: list, templates: dict) -> Optional[dict]:
+def set_anti_affinity(
+    deployment_config: dict, process_name: str, resource: dict, templates: dict
+) -> None:
+    """Attach the expected anti_affinity to the resource."""
+    anti_affinity_node = get_anti_affinity_node(deployment_config, process_name, templates) or {}
+    anti_affinity_zone = get_anti_affinity_zone(deployment_config, process_name, templates) or {}
+    anti_affinity = dict_utils.deep_merge(anti_affinity_node, anti_affinity_zone, concat_lists=True)
+    if len(anti_affinity) > 0:
+        resource["spec"]["template"]["spec"]["affinity"] = anti_affinity
+
+
+def set_command(process: dict, resource: dict) -> None:
+    """Attach the expected command to the resource."""
+    resource["spec"]["template"]["spec"]["containers"][0]["args"] = [
+        "/bin/bash",
+        "-c",
+        process["start_command"],
+    ]
+
+
+def set_environment_variables(deployment_config: dict, resource: dict) -> None:
+    """Format and attach the environment variables to the resource."""
+    secret_variables = get_secret_variables(deployment_config)
+    variables = get_variables(deployment_config)
+    variables["PORT"] = str(SERVICE_PORT)
+
+    environment_variables = [{"name": key, "value": value} for key, value in variables.items()]
+    environment_variables += [
+        {"name": key, "valueFrom": value} for key, value in secret_variables.items()
+    ]
+
+    resource["spec"]["template"]["spec"]["containers"][0]["env"] = environment_variables
+
+
+def set_namespace(deployment_config: dict, resources: list, templates: dict) -> Optional[dict]:
     """Attach the expected namespace to the deployment and return the namespace."""
     namespace = None
-    namespace_name = app_config.get("namespace")
+    namespace_name = deployment_config.get("namespace")
 
     if namespace_name is not None:
         for resource in resources:
@@ -177,13 +233,36 @@ def set_namespace(app_config: dict, resources: list, templates: dict) -> Optiona
     return namespace
 
 
-# pylint: disable=bad-continuation
+def set_node_selector(deployment_config: dict, process_name: str, resource: dict) -> None:
+    """Attach the correct nodeSelector to the resource."""
+    node_selector = deployment_config["nodeSelector"].get(process_name) or deployment_config[
+        "nodeSelector"
+    ].get("default")
+    if node_selector is not None:
+        resource["spec"]["template"]["spec"]["nodeSelector"] = node_selector
+
+
+def set_probes(deployment_config: dict, process_name: str, resource: dict) -> None:
+    """Attach the process' probes to the resource if configured."""
+    if process_name in deployment_config["probes"]:
+        probes_config = deployment_config["probes"][process_name]
+        probes = get_probes(probes_config, SERVICE_PORT)
+        if "livenessProbe" in probes:
+            resource["spec"]["template"]["spec"]["containers"][0]["livenessProbe"] = probes[
+                "livenessProbe"
+            ]
+        if "readinessProbe" in probes:
+            resource["spec"]["template"]["spec"]["containers"][0]["readinessProbe"] = probes[
+                "readinessProbe"
+            ]
+
+
 def set_replicas(
-    app_config: dict, process_name: str, recipe: dict, templates: dict
+    deployment_config: dict, process_name: str, recipe: dict, templates: dict
 ) -> Optional[dict]:
     """Attach the correct Replicas values to the recipe object and return the corresponding
     `hpa` if applicable."""
-    scales = app_config["scales"]
+    scales = deployment_config["scales"]
     scales_config = scales[process_name] if process_name in scales else scales["default"]
     min_replicas = scales_config.get(
         "minReplicas", ReplicasDefaultConfiguration.get_default_min_replicas()
@@ -202,7 +281,9 @@ def set_replicas(
 
     # Create the HorizontalPodAutoscaler for this deployment
 
-    app, sanitized_process_name, metadata_name = get_sanitized_names(app_config, process_name)
+    app, sanitized_process_name, metadata_name = get_sanitized_names(
+        deployment_config, process_name
+    )
 
     template_vars = {
         "app": app,
@@ -211,18 +292,26 @@ def set_replicas(
         "minReplicas": min_replicas,
         "maxReplicas": max_replicas,
         "targetCPUUtilizationPercentage": target_cpu_utilization_percentage,
-        **app_config.get("templateVars", {}),
+        **deployment_config.get("templateVars", {}),
     }
 
     return yaml_lib.parse_yaml(templates["hpa"](template_vars))
 
 
-def set_resources(app_config: dict, process_name: str, recipe: dict) -> None:
+def set_resources(deployment_config: dict, process_name: str, recipe: dict) -> None:
     """Attach the expected resources to the kubernetes recipe."""
-    resources = app_config.get("resources", {})
+    resources = deployment_config.get("resources", {})
     resources_config = (
         resources[process_name] if process_name in resources else resources.get("default")
     )
 
     if resources_config is not None:
         recipe["spec"]["template"]["spec"]["containers"][0]["resources"] = resources_config
+
+
+def set_secret(deployment_config: dict, resource: dict) -> None:
+    """Attach the secret to the resource if present in the configuration."""
+    if "secret" in deployment_config:
+        resource["spec"]["template"]["spec"]["imagePullSecrets"] = [
+            {"name": deployment_config["secret"]}
+        ]

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -365,7 +365,7 @@ ignore-docstrings=yes
 ignore-imports=no
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=100  # a big number because the rule cannot be disabled
 
 
 [BASIC]

--- a/tests/__fixtures__/k8s.py
+++ b/tests/__fixtures__/k8s.py
@@ -55,3 +55,19 @@ hpa = {
         "targetCPUUtilizationPercentage": 75,
     },
 }
+
+# probes
+probes = {
+    "livenessProbe": {
+        "httpGet": {"path": "/heartbeat", "port": 8080},
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "timeoutSeconds": 2,
+    },
+    "readinessProbe": {
+        "httpGet": {"path": "/heartbeat", "port": 8080},
+        "initialDelaySeconds": 5,
+        "periodSeconds": 5,
+        "timeoutSeconds": 1,
+    },
+}

--- a/tests/lib/k8s/test_builders.py
+++ b/tests/lib/k8s/test_builders.py
@@ -36,8 +36,8 @@ class TestK8sBuilders(TestCase):
             return "mock: template_namespace"
 
         return {
-            "anti_affinity_node": check_anti_affinity_node_template,
-            "anti_affinity_zone": check_anti_affinity_zone_template,
+            "anti-affinity-node": check_anti_affinity_node_template,
+            "anti-affinity-zone": check_anti_affinity_zone_template,
             "hpa": check_hpa,
             "namespace": check_namespace,
         }
@@ -176,17 +176,50 @@ class TestK8sBuilders(TestCase):
 
     def test_get_image_name_branch(self):
         """Returns the URL of the docker image if tag and branch are provided"""
-        app_config = {"app": "app", "registry": {"organization": "my-organization"}}
+        app_config = {
+            "app": "app",
+            "registry": {"platform": "docker-hub", "id": "id-1"},
+            "docker": {
+                "registries": {
+                    "docker-hub": [
+                        {"id": "id-1", "organization": "my-organization-1"},
+                        {"id": "id-2", "organization": "my-organization-2"},
+                    ],
+                },
+            },
+        }
         image_url = k8s_builders.get_image_name(
             app_config, {"branch": "feature/api", "tag": "1.0.0-sha-a2b3c4"}
         )
-        self.assertEqual(image_url, "my-organization/app:feature/api")
+        self.assertEqual(image_url, "my-organization-1/app:feature/api")
 
     def test_get_image_name_tag(self):
         """Returns the URL of the docker image if only a tag is provided"""
-        app_config = {"app": "app", "registry": {"organization": "my-organization"}}
+        app_config = {
+            "app": "app",
+            "registry": {"platform": "docker-hub", "id": "id-1"},
+            "docker": {
+                "registries": {
+                    "docker-hub": [
+                        {"id": "id-1", "organization": "my-organization-1"},
+                        {"id": "id-2", "organization": "my-organization-2"},
+                    ],
+                },
+            },
+        }
         image_url = k8s_builders.get_image_name(app_config, {"tag": "1.0.0-sha-a2b3c4"})
-        self.assertEqual(image_url, "my-organization/app:1.0.0-sha-a2b3c4")
+        self.assertEqual(image_url, "my-organization-1/app:1.0.0-sha-a2b3c4")
+
+    def test_get_image_name_registry_not_found(self):
+        """Should throw if the registry is not in the configuration."""
+        app_config = {
+            "app": "app",
+            "registry": {"platform": "docker-hub", "id": "id-not-existing"},
+            "docker": {"registries": {"docker-hub": [],},},
+        }
+
+        with self.assertRaisesRegex(ValueError, 'No registry matching "id-not-existing"'):
+            k8s_builders.get_image_name(app_config, {"tag": "1.0.0-sha-a2b3c4"})
 
     def test_get_probes_both_configured(self):
         """Check that the configuration of probes is correct if both configured"""
@@ -342,6 +375,92 @@ class TestK8sBuilders(TestCase):
             variables, {"VARIABLE_1": "1111", "VARIABLE_2": "3333", "VARIABLE_3": "4444"}
         )
 
+    @patch("nestor_api.lib.k8s.builders.get_anti_affinity_zone", autospec=True)
+    @patch("nestor_api.lib.k8s.builders.get_anti_affinity_node", autospec=True)
+    def test_set_anti_affinity_when_both_true(
+        self, get_anti_affinity_node_mock, get_anti_affinity_zone_mock
+    ):
+        """Should correctly merge both specs."""
+        get_anti_affinity_node_mock.return_value = k8s_fixtures.anti_affinity_node
+        get_anti_affinity_zone_mock.return_value = k8s_fixtures.anti_affinity_zone
+        deployment = {"spec": {"template": {"spec": {}}}}
+
+        k8s_builders.set_anti_affinity({}, "web", deployment, {})
+
+        self.assertEqual(
+            deployment["spec"]["template"]["spec"]["affinity"],
+            {
+                "podAntiAffinity": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": [
+                        {
+                            "weight": 1,
+                            "podAffinityTerm": {
+                                "labelSelector": {
+                                    "matchExpressions": [
+                                        {"key": "app", "operator": "In", "values": ["app-name"]},
+                                        {
+                                            "key": "process",
+                                            "operator": "In",
+                                            "values": ["proc-name"],
+                                        },
+                                    ],
+                                },
+                                "topologyKey": "kubernetes.io/hostname",
+                            },
+                        },
+                        {
+                            "weight": 1,
+                            "podAffinityTerm": {
+                                "labelSelector": {
+                                    "matchExpressions": [
+                                        {"key": "app", "operator": "In", "values": ["app-name"]},
+                                        {
+                                            "key": "process",
+                                            "operator": "In",
+                                            "values": ["proc-name"],
+                                        },
+                                    ],
+                                },
+                                "topologyKey": "failure-domain.beta.kubernetes.io/zone",
+                            },
+                        },
+                    ],
+                },
+            },
+        )
+
+    @patch("nestor_api.lib.k8s.builders.get_anti_affinity_zone", autospec=True)
+    @patch("nestor_api.lib.k8s.builders.get_anti_affinity_node", autospec=True)
+    def test_set_anti_affinity_when_both_false(
+        self, get_anti_affinity_node_mock, get_anti_affinity_zone_mock
+    ):
+        """Should not add the section to the spec."""
+        get_anti_affinity_node_mock.return_value = None
+        get_anti_affinity_zone_mock.return_value = None
+        resource = {"spec": {"template": {"spec": {}}}}
+
+        k8s_builders.set_anti_affinity({}, "web", resource, {})
+
+        self.assertEqual(resource, {"spec": {"template": {"spec": {}}}})
+
+    def test_set_command(self):
+        """Should correctly set the process' command to the resource."""
+        process = {"start_command": "npm start"}
+        resource = {"spec": {"template": {"spec": {"containers": [{}]}}}}
+
+        k8s_builders.set_command(process, resource)
+
+        self.assertEqual(
+            resource,
+            {
+                "spec": {
+                    "template": {
+                        "spec": {"containers": [{"args": ["/bin/bash", "-c", "npm start"]}]},
+                    },
+                },
+            },
+        )
+
     def test_set_namespace_no_namespace(self):
         """Return None if no namespace in config and should not modify resources definition"""
         app_config = {}
@@ -357,6 +476,45 @@ class TestK8sBuilders(TestCase):
         self.assertEqual(namespace, None)
         self.assertEqual(
             resources, [{"metadata": {"name": "hpa"}}, {"metadata": {"name": "deployment"}},]
+        )
+
+    def test_set_environment_variables(self):
+        """Should correctly attach the environment variables."""
+        deployment_config = {
+            "variables": {
+                "app": {"APP_VAR_1": "app_var_1", "APP_VAR_2": "app_var_2",},
+                "ope": {
+                    "PORT": "4242",  # should be overridden
+                    "OPE_VAR_1": "ope_var_1",
+                    "OPE_VAR_2": "ope_var_2",
+                },
+                "secret": {
+                    "SECRET_VAR_1": {"name": "secret-name", "key": "SECRET_VAR_1"},
+                    "SECRET_VAR_2": {"name": "secret-name", "key": "SECRET_VAR_2"},
+                },
+            },
+        }
+        resource = {"spec": {"template": {"spec": {"containers": [{}]}}}}
+
+        k8s_builders.set_environment_variables(deployment_config, resource)
+
+        self.assertEqual(
+            resource["spec"]["template"]["spec"]["containers"][0]["env"],
+            [
+                {"name": "APP_VAR_1", "value": "app_var_1"},
+                {"name": "APP_VAR_2", "value": "app_var_2"},
+                {"name": "PORT", "value": "8080"},
+                {"name": "OPE_VAR_1", "value": "ope_var_1"},
+                {"name": "OPE_VAR_2", "value": "ope_var_2"},
+                {
+                    "name": "SECRET_VAR_1",
+                    "valueFrom": {"secretKeyRef": {"key": "SECRET_VAR_1", "name": "secret-name"}},
+                },
+                {
+                    "name": "SECRET_VAR_2",
+                    "valueFrom": {"secretKeyRef": {"key": "SECRET_VAR_2", "name": "secret-name"}},
+                },
+            ],
         )
 
     @patch("yaml_lib.parse_yaml", autospec=True)
@@ -382,6 +540,119 @@ class TestK8sBuilders(TestCase):
                 {"metadata": {"name": "deployment", "namespace": "namespace"}},
             ],
         )
+
+    def test_set_node_selector_configured(self):
+        """Should use the configured node selector from the configuration."""
+        deployment_config = {"nodeSelector": {"my-process": {"tier": "app"}}}
+        resource = {"spec": {"template": {"spec": {}}}}
+
+        k8s_builders.set_node_selector(deployment_config, "my-process", resource)
+
+        self.assertEqual(resource["spec"]["template"]["spec"]["nodeSelector"], {"tier": "app"})
+
+    def test_set_node_selector_default(self):
+        """Should use the default node selector from the configuration."""
+        deployment_config = {"nodeSelector": {"default": {"tier": "app"}}}
+        resource = {"spec": {"template": {"spec": {}}}}
+
+        k8s_builders.set_node_selector(deployment_config, "my-process-not-configured", resource)
+
+        self.assertEqual(resource["spec"]["template"]["spec"]["nodeSelector"], {"tier": "app"})
+
+    def test_set_node_selector_none(self):
+        """Should not set the node selector if none is found in the configuration."""
+        deployment_config = {"nodeSelector": {}}
+        resource = {"spec": {"template": {"spec": {}}}}
+
+        k8s_builders.set_node_selector(deployment_config, "my-process", resource)
+
+        self.assertEqual(resource["spec"]["template"]["spec"], {})
+
+    @patch("nestor_api.lib.k8s.builders.get_probes", autospec=True)
+    def test_set_probes_configured(self, get_probes_mock):
+        """Should attach the probes to the resource."""
+        get_probes_mock.return_value = k8s_fixtures.probes
+        deployment_config = {"probes": {"my-process": {}}}
+        resource = {"spec": {"template": {"spec": {"containers": [{}]}}}}
+
+        k8s_builders.set_probes(deployment_config, "my-process", resource)
+
+        self.assertEqual(
+            resource["spec"]["template"]["spec"]["containers"][0],
+            {
+                "livenessProbe": {
+                    "httpGet": {"path": "/heartbeat", "port": 8080},
+                    "initialDelaySeconds": 10,
+                    "periodSeconds": 10,
+                    "timeoutSeconds": 2,
+                },
+                "readinessProbe": {
+                    "httpGet": {"path": "/heartbeat", "port": 8080},
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                    "timeoutSeconds": 1,
+                },
+            },
+        )
+
+    @patch("nestor_api.lib.k8s.builders.get_probes", autospec=True)
+    def test_set_probes_only_liveness_configured(self, get_probes_mock):
+        """Should attach the liveness probes to the resource."""
+        get_probes_mock.return_value = {
+            "livenessProbe": k8s_fixtures.probes["livenessProbe"],
+        }
+        deployment_config = {"probes": {"my-process": {}}}
+        resource = {"spec": {"template": {"spec": {"containers": [{}]}}}}
+
+        k8s_builders.set_probes(deployment_config, "my-process", resource)
+
+        self.assertEqual(
+            resource["spec"]["template"]["spec"]["containers"][0],
+            {
+                "livenessProbe": {
+                    "httpGet": {"path": "/heartbeat", "port": 8080},
+                    "initialDelaySeconds": 10,
+                    "periodSeconds": 10,
+                    "timeoutSeconds": 2,
+                },
+            },
+        )
+
+    @patch("nestor_api.lib.k8s.builders.get_probes", autospec=True)
+    def test_set_probes_only_readiness_configured(self, get_probes_mock):
+        """Should attach the readiness probes to the resource."""
+        get_probes_mock.return_value = {
+            "readinessProbe": k8s_fixtures.probes["readinessProbe"],
+        }
+        deployment_config = {"probes": {"my-process": {}}}
+        resource = {"spec": {"template": {"spec": {"containers": [{}]}}}}
+
+        k8s_builders.set_probes(deployment_config, "my-process", resource)
+
+        self.assertEqual(
+            resource["spec"]["template"]["spec"]["containers"][0],
+            {
+                "readinessProbe": {
+                    "httpGet": {"path": "/heartbeat", "port": 8080},
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                    "timeoutSeconds": 1,
+                },
+            },
+        )
+
+    @patch("nestor_api.lib.k8s.builders.get_probes", autospec=True)
+    def test_set_probes_not_configured(self, get_probes_mock):
+        """Should not attach the probes to the resource if not configured."""
+        deployment_config = {"probes": {}}
+        resource = {"spec": {"template": {"spec": {"containers": [{}]}}}}
+
+        k8s_builders.set_probes(deployment_config, "my-process", resource)
+
+        self.assertEqual(
+            resource["spec"]["template"]["spec"]["containers"][0], {},
+        )
+        get_probes_mock.assert_not_called()
 
     def test_set_replicas_min_replicas_zero(self):
         """Return None and set replicas to 0 in the recipe"""
@@ -599,4 +870,27 @@ class TestK8sBuilders(TestCase):
                     }
                 },
             },
+        )
+
+    def test_set_secret_configured(self):
+        """Should attach the configured secret to the resource."""
+        deployment_config = {"secret": "secret-registry"}
+        resource = {"spec": {"template": {"spec": {}}}}
+
+        k8s_builders.set_secret(deployment_config, resource)
+
+        self.assertEqual(
+            resource["spec"]["template"]["spec"],
+            {"imagePullSecrets": [{"name": "secret-registry"}]},
+        )
+
+    def test_set_secret_not_configured(self):
+        """Should not attach the secret if none configured."""
+        deployment_config = {}
+        resource = {"spec": {"template": {"spec": {}}}}
+
+        k8s_builders.set_secret(deployment_config, resource)
+
+        self.assertEqual(
+            resource["spec"]["template"]["spec"], {},
         )


### PR DESCRIPTION
This PR includes all the setters that will then be used when configuring the deployment resources.
I choose to create a dedicated PR to keep things simple.