### PR TITLE
Update github provider error handling

### DIFF
--- a/nestor_api/adapters/git/abstract_git_provider.py
+++ b/nestor_api/adapters/git/abstract_git_provider.py
@@ -1,6 +1,7 @@
 """Abstract adapter for git provider."""
 
 from abc import ABC, abstractmethod
+from enum import Enum
 
 
 class AbstractGitProvider(ABC):
@@ -12,20 +13,38 @@ class AbstractGitProvider(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_branch(self, organization: str, app_name: str, branch_name: str):
+    def get_branch(self, organization: str, repository_name: str, branch_name: str):
         """Get branch information."""
         raise NotImplementedError()
 
     @abstractmethod
-    def create_branch(self, organization: str, app_name: str, branch_name: str, ref: str):
+    def create_branch(self, organization: str, repository_name: str, branch_name: str, ref: str):
         """Create a branch."""
         raise NotImplementedError()
 
     @abstractmethod
-    def protect_branch(self, organization: str, app_name: str, branch_name: str, user_login: str):
+    def protect_branch(
+        self, organization: str, repository_name: str, branch_name: str, user_login: str
+    ):
         """Protect a branch."""
         raise NotImplementedError()
 
 
+class GitResource(Enum):
+    """Enum for Git resource."""
+
+    BRANCH = "BRANCH"
+    REPOSITORY = "REPOSITORY"
+    USER = "USER"
+
+
 class GitProviderError(Exception):
     """Base error for git provider."""
+
+
+class GitResourceNotFoundError(GitProviderError):
+    """The resource has not been found."""
+
+    def __init__(self, resource: GitResource):
+        super().__init__()
+        self.resource = resource

--- a/nestor_api/adapters/git/github_git_provider.py
+++ b/nestor_api/adapters/git/github_git_provider.py
@@ -1,11 +1,16 @@
 """Git provider adapter for Github."""
 
 from http import HTTPStatus
-from typing import Optional, Union
+from typing import Union
 
-from github import AuthenticatedUser, Branch, Github, GithubException, NamedUser
+from github import AuthenticatedUser, Branch, Github, GithubException, NamedUser, Repository
 
-from nestor_api.adapters.git.abstract_git_provider import AbstractGitProvider, GitProviderError
+from nestor_api.adapters.git.abstract_git_provider import (
+    AbstractGitProvider,
+    GitProviderError,
+    GitResource,
+    GitResourceNotFoundError,
+)
 from nestor_api.config.git import GitConfiguration
 
 
@@ -24,40 +29,44 @@ class GitHubGitProvider(AbstractGitProvider):
         except GithubException as err:
             raise _format_error(err)
 
-    def get_branch(
-        self, organization: str, app_name: str, branch_name: str
-    ) -> Optional[Branch.Branch]:
-        """Get branch information."""
+    def _get_repository(self, organization: str, repository_name: str) -> Repository.Repository:
+        """Get repository information."""
         try:
-            repository = self.__client.get_repo(f"{organization}/{app_name}")
+            return self.__client.get_repo(f"{organization}/{repository_name}")
+        except GithubException as err:
+            if err.status == HTTPStatus.NOT_FOUND:
+                raise GitResourceNotFoundError(GitResource.REPOSITORY)
+            raise _format_error(err)
+
+    def get_branch(
+        self, organization: str, repository_name: str, branch_name: str
+    ) -> Branch.Branch:
+        """Get branch information."""
+        repository = self._get_repository(organization, repository_name)
+        try:
             return repository.get_branch(branch=branch_name)
         except GithubException as err:
             if err.status == HTTPStatus.NOT_FOUND:
-                return None
+                raise GitResourceNotFoundError(GitResource.BRANCH)
             raise _format_error(err)
 
     def create_branch(
-        self, organization: str, app_name: str, branch_name: str, ref: str
+        self, organization: str, repository_name: str, branch_name: str, ref: str
     ) -> Branch.Branch:
         """Create a branch."""
+        repository = self._get_repository(organization, repository_name)
         try:
-            repository = self.__client.get_repo(f"{organization}/{app_name}")
             repository.create_git_ref(f"refs/heads/{branch_name}", ref)
-            branch = self.get_branch(organization, app_name, branch_name)
-            if branch is None:
-                raise GitProviderError("Could not retrieve branch after ref creation")
-            return branch
+            return self.get_branch(organization, repository_name, branch_name)
         except GithubException as err:
             raise _format_error(err)
 
     def protect_branch(
-        self, organization: str, app_name: str, branch_name: str, user_login: str
+        self, organization: str, repository_name: str, branch_name: str, user_login: str
     ) -> None:
         """Protect a branch."""
         try:
-            branch = self.get_branch(organization, app_name, branch_name)
-            if branch is None:
-                raise GitProviderError("Branch not found")
+            branch = self.get_branch(organization, repository_name, branch_name)
             branch.edit_protection(enforce_admins=False, user_push_restrictions=[user_login])
         except GithubException as err:
             raise _format_error(err)

--- a/tests/adapters/git/test_github_git_provider.py
+++ b/tests/adapters/git/test_github_git_provider.py
@@ -1,9 +1,13 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from github import AuthenticatedUser, Branch, GithubException
+from github import AuthenticatedUser, Branch, GithubException, Repository
 
-from nestor_api.adapters.git.abstract_git_provider import GitProviderError
+from nestor_api.adapters.git.abstract_git_provider import (
+    GitProviderError,
+    GitResource,
+    GitResourceNotFoundError,
+)
 from nestor_api.adapters.git.github_git_provider import GitHubGitProvider
 
 
@@ -40,54 +44,88 @@ class TestGitHubGitProvider(TestCase):
         with self.assertRaises(GitProviderError):
             github_provider.get_user_info()
 
-    def test_get_branch(self, github_mock):
+    def test_get_repository(self, github_mock):
+        """Should get the repository information."""
+        fake_repo = MagicMock(spec=Repository.Repository)
+        instance = github_mock.return_value
+        instance.get_repo.return_value = fake_repo
+        github_provider = GitHubGitProvider()
+
+        result = github_provider._get_repository("organization", "fake-project")
+
+        self.assertEqual(result, fake_repo)
+        instance.get_repo.assert_called_with("organization/fake-project")
+
+    def test_get_repository_on_non_existing_repository(self, github_mock):
+        """Should raise a GitResourceNotFoundError error."""
+        instance = github_mock.return_value
+        instance.get_repo.side_effect = GithubException(404, "fake error")
+        github_provider = GitHubGitProvider()
+
+        with self.assertRaises(GitResourceNotFoundError) as context:
+            github_provider._get_repository("organization", "fake-project")
+
+        self.assertEqual(context.exception.resource, GitResource.REPOSITORY)
+
+    def test_get_repository_failing(self, github_mock):
+        """Should raise a GitProviderError error."""
+        instance = github_mock.return_value
+        instance.get_repo.side_effect = GithubException(500, "fake error")
+        github_provider = GitHubGitProvider()
+
+        with self.assertRaises(GitProviderError):
+            github_provider._get_repository("organization", "fake-project")
+
+    @patch.object(GitHubGitProvider, "_get_repository", autospec=True)
+    def test_get_branch(self, get_repository_mock, _github_mock):
         """Should get the branch data."""
         # Mocks
         fake_branch_result = MagicMock(spec=Branch.Branch)
-        instance = github_mock.return_value
-        instance.get_repo.return_value.get_branch.return_value = fake_branch_result
+        get_repository_mock.return_value.get_branch.return_value = fake_branch_result
         github_provider = GitHubGitProvider()
 
         # Test
         result = github_provider.get_branch("organization", "fake-project", "fake-branch")
 
         # Assertions
-        instance.get_repo.assert_called_once_with("organization/fake-project")
-        instance.get_repo.return_value.get_branch.assert_called_once_with(branch="fake-branch")
+        get_repository_mock.assert_called_once_with(github_provider, "organization", "fake-project")
+        get_repository_mock.return_value.get_branch.assert_called_once_with(branch="fake-branch")
         self.assertEqual(result, fake_branch_result)
 
-    def test_get_branch_not_found(self, github_mock):
-        """Should return None when the branch is not found."""
+    @patch.object(GitHubGitProvider, "_get_repository", autospec=True)
+    def test_get_branch_not_found(self, get_repository_mock, _github_mock):
+        """Should raise a GitResourceNotFoundError error
+        when the branch is not found."""
         # Mocks
-        instance = github_mock.return_value
-        instance.get_repo.return_value.get_branch.side_effect = GithubException(
+        get_repository_mock.return_value.get_branch.side_effect = GithubException(
             404, "branch not found"
         )
         github_provider = GitHubGitProvider()
 
-        # Test
-        result = github_provider.get_branch("organization", "fake-project", "fake-branch")
+        # Tests
+        with self.assertRaises(GitResourceNotFoundError) as context:
+            github_provider.get_branch("organization", "fake-project", "fake-branch")
 
         # Assertions
-        instance.get_repo.assert_called_once_with("organization/fake-project")
-        instance.get_repo.return_value.get_branch.assert_called_once_with(branch="fake-branch")
-        self.assertIsNone(result)
+        self.assertEqual(context.exception.resource, GitResource.BRANCH)
+        get_repository_mock.assert_called_once_with(github_provider, "organization", "fake-project")
+        get_repository_mock.return_value.get_branch.assert_called_once_with(branch="fake-branch")
 
-    def test_get_branch_failing(self, github_mock):
+    @patch.object(GitHubGitProvider, "_get_repository", autospec=True)
+    def test_get_branch_failing(self, get_repository_mock, _github_mock):
         """Should raise a GitProviderError when an unhandled error occurs."""
-        instance = github_mock.return_value
-        instance.get_repo.return_value.get_branch.side_effect = GithubException(500, "fake error")
+        get_repository_mock.return_value.get_branch.side_effect = GithubException(500, "fake error")
         github_provider = GitHubGitProvider()
 
         with self.assertRaises(GitProviderError):
             github_provider.get_branch("organization", "fake-project", "fake-branch")
 
+    @patch.object(GitHubGitProvider, "_get_repository", autospec=True)
     @patch.object(GitHubGitProvider, "get_branch", autospec=True)
-    def test_create_branch(self, get_branch_mock, github_mock):
+    def test_create_branch(self, get_branch_mock, get_repository_mock, _github_mock):
         """Should create the branch and return its data."""
         # Mocks
         fake_branch_result = MagicMock(spec=Branch.Branch)
-        instance = github_mock.return_value
         get_branch_mock.return_value = fake_branch_result
         github_provider = GitHubGitProvider()
 
@@ -97,8 +135,8 @@ class TestGitHubGitProvider(TestCase):
         )
 
         # Assertions
-        instance.get_repo.assert_called_once_with("organization/fake-project")
-        instance.get_repo.return_value.create_git_ref.assert_called_once_with(
+        get_repository_mock.assert_called_once_with(github_provider, "organization", "fake-project")
+        get_repository_mock.return_value.create_git_ref.assert_called_once_with(
             "refs/heads/fake-branch", "fake-sha1"
         )
         get_branch_mock.assert_called_once_with(
@@ -106,24 +144,50 @@ class TestGitHubGitProvider(TestCase):
         )
         self.assertEqual(result, fake_branch_result)
 
+    @patch.object(GitHubGitProvider, "_get_repository", autospec=True)
     @patch.object(GitHubGitProvider, "get_branch", autospec=True)
-    def test_create_branch_failing_to_retrieve_branch_data(self, get_branch_mock, _github_mock):
+    def test_create_branch_failing_to_retrieve_branch_data(
+        self, get_branch_mock, get_repository_mock, _github_mock
+    ):
         """Should raise an error when failing to retrieve branch data."""
-        get_branch_mock.return_value = None
+        get_branch_mock.side_effect = GitResourceNotFoundError(GitResource.BRANCH)
         github_provider = GitHubGitProvider()
 
-        with self.assertRaisesRegex(
-            GitProviderError, "Could not retrieve branch after ref creation"
-        ):
+        with self.assertRaises(GitResourceNotFoundError) as context:
             github_provider.create_branch(
                 "organization", "fake-project", "fake-branch", "fake-sha1"
             )
 
-    def test_create_branch_failing(self, github_mock):
+        get_repository_mock.assert_called_with(github_provider, "organization", "fake-project")
+        self.assertEqual(context.exception.resource, GitResource.BRANCH)
+
+    @patch.object(GitHubGitProvider, "_get_repository", autospec=True)
+    def test_create_branch_with_error_retrieving_repository(
+        self, get_repository_mock, _github_mock
+    ):
+        """Should rethrow error."""
+        # Mocks
+        error = GitProviderError()
+        get_repository_mock.side_effect = error
+        github_provider = GitHubGitProvider()
+
+        # Test
+        with self.assertRaises(GitProviderError) as context:
+            github_provider.create_branch(
+                "organization", "fake-project", "fake-branch", "fake-sha1"
+            )
+
+        self.assertEqual(error, context.exception)
+
+    @patch.object(GitHubGitProvider, "_get_repository", autospec=True)
+    def test_create_branch_with_error_creating_ref(self, get_repository_mock, _github_mock):
         """Should raise a GitProviderError when an unhandled error occurs."""
         # Mocks
-        instance = github_mock.return_value
-        instance.get_repo.side_effect = GithubException(500, "fake error")
+        fake_repository_result = MagicMock(spec=Repository.Repository)
+        get_repository_mock.return_value = fake_repository_result
+        get_repository_mock.return_value.create_git_ref.side_effect = GithubException(
+            500, "fake error"
+        )
         github_provider = GitHubGitProvider()
 
         # Test
@@ -149,12 +213,14 @@ class TestGitHubGitProvider(TestCase):
     def test_protect_branch_on_non_existing_branch(self, get_branch_mock, _github_mock):
         """Should raise an error when trying to protect an non existing branch."""
         github_provider = GitHubGitProvider()
-        get_branch_mock.return_value = None
+        get_branch_mock.side_effect = GitResourceNotFoundError(GitResource.BRANCH)
 
-        with self.assertRaisesRegex(GitProviderError, "Branch not found"):
+        with self.assertRaises(GitResourceNotFoundError) as context:
             github_provider.protect_branch(
                 "organization", "fake-project", "fake-branch", "user_login"
             )
+
+        self.assertEqual(context.exception.resource, GitResource.BRANCH)
 
     @patch.object(GitHubGitProvider, "get_branch", autospec=True)
     def test_protect_branch_failing(self, get_branch_mock, _github_mock):


### PR DESCRIPTION
In this PR:
- Replace error handling leveraging exceptions
- Split get_branch in get_repository and get_branch to improve readability
- Remove business notions from library `app_name` => `repository_name`