### PR TITLE
Bump python version from 3.7 to 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8

--- a/Pipfile
+++ b/Pipfile
@@ -22,7 +22,7 @@ pygithub = "==1.51"
 pybars3 = "0.9.7"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ac1b031b20e27d8320c1fefcfa30d69b9842f88ed5bde5f763534ce690771c4b"
+            "sha256": "2694415feb99127aeee3e720b777a185b1d9ce0a482c7f7a85099ea57f308251"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -69,14 +69,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
-                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.7.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -237,14 +229,6 @@
                 "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
             "version": "==1.12.1"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.1.0"
         }
     },
     "develop": {
@@ -476,7 +460,6 @@
                 "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
                 "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
-            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
             "version": "==1.4.1"
         },
         "typing-extensions": {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [Getting started](./docs/getting_started.md).
 
 ## Installing
 
-Python 3.7 or above.
+Python 3.8 or above.
 
 Dependencies are managed by [Pipenv](https://github.com/pypa/pipenv).
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 # Global options:
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 
 # Per-module options:
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name=nestor_api.__name__,
     version=nestor_api.__version__,
     url="https://github.com/ChauffeurPrive/nestor-api",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     author_email="tech-admin@kapten.com",
     description="API to manages kubernetes deployments",
     packages=find_packages(),


### PR DESCRIPTION
This PR bump python to version 3.8.

The procedure to migrate locally is [available in the Wiki](https://github.com/ChauffeurPrive/nestor-api/wiki/Migrating-from-python-3.7-to-python-3.8-on-MacOS).