### PR TITLE
Documentation of build API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,10 @@
+# API
+
+## Builds
+
+### POST `/api/builds/:app`
+
+<a name="api-build-api"></a>
+
+Builds the docker image of an application from the first step defined in the workflow with a unique
+tag and uploads it to the configured Docker registry.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,3 +8,12 @@
 Create an account with sufficient permissions to be able to merge on protected branches using the workflow features.
 
 **Supported host:** GitHub
+
+## Configuration
+
+### Build
+
+You should create a hook triggered every time new commits are merged on the first step of your workflow (e.g. master) calling [Nestor's build API](./api.md#api-build-api).
+This will create a new docker image corresponding to this new version.
+Nestor will tag this image with a reference to the version of your application and the commit hash before pushing it to your Docker registry.
+**This will guarantee that you are using the same version for all environment.**

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -14,6 +14,9 @@ Create an account with sufficient permissions to be able to merge on protected b
 ### Build
 
 You should create a hook triggered every time new commits are merged on the first step of your workflow (e.g. master) calling [Nestor's build API](./api.md#api-build-api).
+
 This will create a new docker image corresponding to this new version.
+
 Nestor will tag this image with a reference to the version of your application and the commit hash before pushing it to your Docker registry.
+
 **This will guarantee that you are using the same version for all environment.**


### PR DESCRIPTION
Add documentation for build API.
Explain in the `getting started` what should be configured and why. 