### PR TITLE
Create a "report" when deploying an app

### DIFF
--- a/nestor_api/lib/k8s/cli.py
+++ b/nestor_api/lib/k8s/cli.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from typing import List
 
 from nestor_api.config.k8s import K8sConfiguration
 import nestor_api.lib.io as io
@@ -17,14 +18,15 @@ def _build_kubectl_env() -> dict:
 
 
 def fetch_resource_configuration(
-    cluster_name: str, namespace: str, app_name: str, resource_type: K8sResourceType
+    cluster_name: str, namespace: str, app_name: str, resources: List[K8sResourceType]
 ) -> dict:
     """Fetch a resource's configuration using kubectl."""
+    resources_str = ",".join([str(resource) for resource in resources])
     command = (
         "kubectl "
         f"--context {cluster_name} "
         f"--namespace {namespace} "
-        f"get {str(resource_type)} "
+        f"get {resources_str} "
         "--output=json "
         f"--selector app={app_name}"
     )

--- a/nestor_api/lib/k8s/cli.py
+++ b/nestor_api/lib/k8s/cli.py
@@ -7,7 +7,7 @@ from typing import List
 from nestor_api.config.k8s import K8sConfiguration
 import nestor_api.lib.io as io
 
-from .enums.k8s_resource_type import K8sResourceType
+from .enums.k8s_resource_kind import K8sResourceKind
 
 
 def _build_kubectl_env() -> dict:
@@ -18,7 +18,7 @@ def _build_kubectl_env() -> dict:
 
 
 def fetch_resource_configuration(
-    cluster_name: str, namespace: str, app_name: str, resources: List[K8sResourceType]
+    cluster_name: str, namespace: str, app_name: str, resources: List[K8sResourceKind]
 ) -> dict:
     """Fetch a resource's configuration using kubectl."""
     resources_str = ",".join([str(resource) for resource in resources])

--- a/nestor_api/lib/k8s/deployment.py
+++ b/nestor_api/lib/k8s/deployment.py
@@ -1,6 +1,7 @@
 """Kubernetes deployment library."""
 
 import os
+from typing import Optional
 
 from nestor_api.config.k8s import K8sConfiguration
 import nestor_api.lib.config as config
@@ -13,14 +14,13 @@ from .enums.k8s_resource_type import K8sResourceType
 WEB_PROCESS_NAME = "web"
 
 
-def deploy_app(deployment_config: dict, config_dir: str, tag_to_deploy: str) -> None:
+def deploy_app(deployment_config: dict, config_dir: str, tag_to_deploy: str) -> dict:
     """Deploy a new version of an application on kubernetes
     following the provided configuration."""
     templates_path = os.path.join(config_dir, K8sConfiguration.get_templates_dir())
     templates = builders.load_templates(templates_path)
 
-    # Awaiting for implementation
-    # --> Fetch the previous configuration
+    previous_status = get_deployment_status(deployment_config)
 
     if has_process(deployment_config, WEB_PROCESS_NAME):
         deploy_app_ingress(deployment_config, WEB_PROCESS_NAME, templates)
@@ -28,10 +28,10 @@ def deploy_app(deployment_config: dict, config_dir: str, tag_to_deploy: str) -> 
     deployment_yaml = builders.build_deployment_yaml(deployment_config, templates, tag_to_deploy)
     write_and_deploy_configuration(deployment_config["cluster_name"], deployment_yaml)
 
-    # Awaiting for implementation
-    # --> Fetch the new configuration
-    # --> Compare the 2 configurations and generate a report
-    # --> Return the report
+    new_status = get_deployment_status(deployment_config)
+    status_changes = get_deployement_statuses_diff(previous_status, new_status)
+
+    return status_changes
 
 
 def deploy_app_ingress(deployment_config: dict, process_name: str, templates: dict):
@@ -93,6 +93,50 @@ def get_deployment_status(deployment_config: dict) -> dict:
     status["env"] = _build_variable_status(items[0])
 
     return status
+
+
+def _get_name(item: dict) -> str:
+    return item["name"]
+
+
+def _compare_job_keys(job_1: dict, job_2: dict) -> Optional[dict]:
+    differences = {}
+    for key in job_1:
+        if job_1[key] != job_2[key]:
+            differences[key] = {"old": job_1[key], "new": job_2[key]}
+
+    return {"name": job_1["name"], "values": differences} if len(differences) > 0 else None
+
+
+def _compare_env_vars(var_1: dict, var_2: dict) -> Optional[dict]:
+    value_1 = var_1["value"] if "value" in var_1 else var_1["valueFrom"]
+    value_2 = var_2["value"] if "value" in var_2 else var_2["valueFrom"]
+    return (
+        None
+        if value_1 == value_2
+        else {"name": var_1["name"], "value": {"old": value_1, "new": value_2}}
+    )
+
+
+def get_deployement_statuses_diff(deployment_1: dict, deployment_2: dict) -> dict:
+    """Compute the differences between 2 deployement statuses."""
+    return {
+        "processes": list_utils.compute_diff(
+            deployment_1["processes"],
+            deployment_2["processes"],
+            key=_get_name,
+            comparator=_compare_job_keys,
+        ),
+        "cronjobs": list_utils.compute_diff(
+            deployment_1["cronjobs"],
+            deployment_2["cronjobs"],
+            key=_get_name,
+            comparator=_compare_job_keys,
+        ),
+        "env": list_utils.compute_diff(
+            deployment_1["env"], deployment_2["env"], key=_get_name, comparator=_compare_env_vars
+        ),
+    }
 
 
 def has_process(deployment_config: dict, process_name: str) -> bool:

--- a/nestor_api/lib/k8s/enums/k8s_resource_kind.py
+++ b/nestor_api/lib/k8s/enums/k8s_resource_kind.py
@@ -3,11 +3,11 @@
 from enum import Enum
 
 
-class K8sResourceType(Enum):
+class K8sResourceKind(Enum):
     """An enum representing the different resources kinds"""
 
-    DEPLOYMENTS = "deployments"
-    CRONJOBS = "cronjobs"
+    DEPLOYMENT = "Deployment"
+    CRONJOB = "CronJob"
 
     def __str__(self):
         return str(self.value)

--- a/nestor_api/lib/k8s/enums/k8s_resource_type.py
+++ b/nestor_api/lib/k8s/enums/k8s_resource_type.py
@@ -6,7 +6,8 @@ from enum import Enum
 class K8sResourceType(Enum):
     """An enum representing the different resources kinds"""
 
-    DEPLOYMENT = "deployment"
+    DEPLOYMENTS = "deployments"
+    CRONJOBS = "cronjobs"
 
     def __str__(self):
         return str(self.value)

--- a/nestor_api/utils/list.py
+++ b/nestor_api/utils/list.py
@@ -3,6 +3,48 @@
 from typing import Any, Callable, Optional
 
 
+def compute_diff(
+    list_1: list,
+    list_2: list,
+    key=lambda x: x,
+    comparator=lambda v1, v2: None if v1 == v2 else {"old": v1, "new": v2},
+) -> dict:
+    """Compute the differences between two lists. It assumes `list_1` is the previous state
+    and `list_2` the new one when comparing."""
+    diff: dict = {"added": [], "modified": [], "removed": []}
+
+    list_1 = list_1.copy()
+    list_2 = list_2.copy()
+    list_1.sort(key=key)
+    list_2.sort(key=key)
+
+    idx_1 = 0
+    idx_2 = 0
+    while idx_1 < len(list_1) and idx_2 < len(list_2):
+        key_1 = key(list_1[idx_1])
+        key_2 = key(list_2[idx_2])
+        if key_1 < key_2:
+            diff["removed"].append(list_1[idx_1])
+            idx_1 += 1
+        elif key_1 > key_2:
+            diff["added"].append(list_2[idx_2])
+            idx_2 += 1
+        else:
+            comparison = comparator(list_1[idx_1], list_2[idx_2])
+            if comparison is not None:
+                diff["modified"].append(comparison)
+            idx_1 += 1
+            idx_2 += 1
+
+    if idx_1 < len(list_1):
+        diff["removed"].extend(list_1[idx_1:])
+
+    if idx_2 < len(list_2):
+        diff["added"].extend(list_2[idx_2:])
+
+    return diff
+
+
 def flatten(double_list: list) -> list:
     """Flatten a list of list into a simple list.
 

--- a/tests/__fixtures__/k8s.py
+++ b/tests/__fixtures__/k8s.py
@@ -92,3 +92,51 @@ CRONJOB_SPEC_EXPECTED_OUTPUT = """spec:
       job: spec
   schedule: '*/30 * * * *'
 """
+
+# get_deployment_status
+DEPLOYMENT_STATUS_ITEM_PROCESS = {
+    "kind": "Deployment",
+    "spec": {
+        "template": {
+            "metadata": {"labels": {"process": "my-process"}},
+            "spec": {
+                "containers": [
+                    {
+                        "image": "0.1.0-sha-1ab23cd",
+                        "args": ["/bin/bash", "-c", "npm start:process"],
+                        "env": [
+                            {"name": "VAR_A", "value": "VALUE_A"},
+                            {"name": "VAR_B", "value": "VALUE_B"},
+                        ],
+                    },
+                ],
+            },
+        },
+    },
+}
+
+DEPLOYMENT_STATUS_ITEM_CRONJOB = {
+    "kind": "CronJob",
+    "spec": {
+        "schedule": "0 0 * * *",
+        "jobTemplate": {
+            "spec": {
+                "template": {
+                    "metadata": {"labels": {"process": "my-cron"}},
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "0.1.0-sha-1ab23cd",
+                                "args": ["/bin/bash", "-c", "npm start:cron"],
+                                "env": [
+                                    {"name": "VAR_A", "value": "VALUE_A"},
+                                    {"name": "VAR_B", "value": "VALUE_B"},
+                                ],
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    },
+}

--- a/tests/lib/k8s/test_cli.py
+++ b/tests/lib/k8s/test_cli.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import nestor_api.lib.k8s.cli as cli
-from nestor_api.lib.k8s.enums.k8s_resource_type import K8sResourceType
+from nestor_api.lib.k8s.enums.k8s_resource_kind import K8sResourceKind
 
 
 class TestK8sCli(TestCase):
@@ -14,7 +14,7 @@ class TestK8sCli(TestCase):
         io_mock.execute.return_value = '{"key": "value"}'
 
         result = cli.fetch_resource_configuration(
-            "cluster", "namespace", "my-app", [K8sResourceType.DEPLOYMENTS]
+            "cluster", "namespace", "my-app", [K8sResourceKind.DEPLOYMENT]
         )
 
         self.assertEqual(result, {"key": "value"})
@@ -23,7 +23,7 @@ class TestK8sCli(TestCase):
                 "kubectl "
                 "--context cluster "
                 "--namespace namespace "
-                "get deployments "
+                "get Deployment "
                 "--output=json "
                 "--selector app=my-app"
             ),
@@ -37,10 +37,7 @@ class TestK8sCli(TestCase):
         io_mock.execute.return_value = '{"key": "value"}'
 
         result = cli.fetch_resource_configuration(
-            "cluster",
-            "namespace",
-            "my-app",
-            [K8sResourceType.DEPLOYMENTS, K8sResourceType.CRONJOBS],
+            "cluster", "namespace", "my-app", [K8sResourceKind.DEPLOYMENT, K8sResourceKind.CRONJOB],
         )
 
         self.assertEqual(result, {"key": "value"})
@@ -49,7 +46,7 @@ class TestK8sCli(TestCase):
                 "kubectl "
                 "--context cluster "
                 "--namespace namespace "
-                "get deployments,cronjobs "
+                "get Deployment,CronJob "
                 "--output=json "
                 "--selector app=my-app"
             ),

--- a/tests/lib/k8s/test_deployment.py
+++ b/tests/lib/k8s/test_deployment.py
@@ -9,6 +9,8 @@ import tests.__fixtures__.k8s as k8s_fixtures
 class TestK8sDeployment(TestCase):
     @patch("nestor_api.lib.k8s.deployment.write_and_deploy_configuration", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.deploy_app_ingress", autospec=True)
+    @patch("nestor_api.lib.k8s.deployment.get_deployement_statuses_diff", autospec=True)
+    @patch("nestor_api.lib.k8s.deployment.get_deployment_status", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.K8sConfiguration", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.has_process", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.builders", autospec=True)
@@ -17,6 +19,8 @@ class TestK8sDeployment(TestCase):
         builders_mock,
         has_web_process_mock,
         k8s_config_mock,
+        get_deployement_status_mock,
+        get_deployement_statuses_diff_mock,
         deploy_app_ingress_mock,
         write_and_deploy_configuration_mock,
     ):
@@ -26,21 +30,29 @@ class TestK8sDeployment(TestCase):
         builders_mock.load_templates.return_value = {}
         has_web_process_mock.return_value = True
         builders_mock.build_deployment_yaml.return_value = "deployment: app"
+        report = {}
+        get_deployement_statuses_diff_mock.return_value = report
 
         # Setup
         deployment_config = {"cluster_name": "my-cluster"}
 
         # Test
-        k8s_lib.deploy_app(deployment_config, "/config", "tag-to-deploy")
+        result = k8s_lib.deploy_app(deployment_config, "/config", "tag-to-deploy")
 
         # Assertions
+        self.assertEqual(result, report)
+
         builders_mock.load_templates.assert_called_once_with("/config/templates-dir")
 
+        self.assertEqual(get_deployement_status_mock.call_count, 2)
+        get_deployement_statuses_diff_mock.assert_called_once()
         deploy_app_ingress_mock.assert_called_once()
         write_and_deploy_configuration_mock.assert_called_once_with("my-cluster", "deployment: app")
 
     @patch("nestor_api.lib.k8s.deployment.write_and_deploy_configuration", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.deploy_app_ingress", autospec=True)
+    @patch("nestor_api.lib.k8s.deployment.get_deployement_statuses_diff", autospec=True)
+    @patch("nestor_api.lib.k8s.deployment.get_deployment_status", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.K8sConfiguration", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.has_process", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.builders", autospec=True)
@@ -49,6 +61,8 @@ class TestK8sDeployment(TestCase):
         builders_mock,
         has_web_process_mock,
         k8s_config_mock,
+        get_deployement_status_mock,
+        get_deployement_statuses_diff_mock,
         deploy_app_ingress_mock,
         write_and_deploy_configuration_mock,
     ):
@@ -58,15 +72,22 @@ class TestK8sDeployment(TestCase):
         builders_mock.load_templates.return_value = {}
         has_web_process_mock.return_value = False
         builders_mock.build_deployment_yaml.return_value = "deployment: app"
+        report = {}
+        get_deployement_statuses_diff_mock.return_value = report
 
         # Setup
         deployment_config = {"cluster_name": "my-cluster"}
 
         # Test
-        k8s_lib.deploy_app(deployment_config, "/config", "tag-to-deploy")
+        result = k8s_lib.deploy_app(deployment_config, "/config", "tag-to-deploy")
 
         # Assertions
+        self.assertEqual(result, report)
+
         builders_mock.load_templates.assert_called_once_with("/config/templates-dir")
+
+        self.assertEqual(get_deployement_status_mock.call_count, 2)
+        get_deployement_statuses_diff_mock.assert_called_once()
 
         deploy_app_ingress_mock.assert_not_called()
         write_and_deploy_configuration_mock.assert_called_once_with("my-cluster", "deployment: app")
@@ -221,6 +242,139 @@ class TestK8sDeployment(TestCase):
 
         with self.assertRaisesRegex(Exception, 'Unknown item kind "Unknown"'):
             k8s_lib.get_deployment_status(deployment_config)
+
+    def test_get_deployment_statuses_diff_when_no_diff(self):
+        """Should return a report with no differences."""
+        previous_status = {
+            "processes": [
+                {"name": "proc-1", "image": "0.1.0-sha-1ab", "command": "npm start:proc-1"},
+            ],
+            "cronjobs": [
+                {
+                    "name": "cron-1",
+                    "image": "0.1.0-sha-1ab23cd",
+                    "command": "npm start:cron",
+                    "schedule": "0 0 * * *",
+                },
+            ],
+            "env": [
+                {"name": "VAR_A", "value": "VALUE_A"},
+                {"name": "VAR_B", "valueFrom": {"name": "my-app", "key": "VAR_B"}},
+            ],
+        }
+        new_status = previous_status
+
+        diff = k8s_lib.get_deployement_statuses_diff(previous_status, new_status)
+
+        self.assertEqual(
+            diff,
+            {
+                "processes": {"added": [], "modified": [], "removed": []},
+                "cronjobs": {"added": [], "modified": [], "removed": []},
+                "env": {"added": [], "modified": [], "removed": []},
+            },
+        )
+
+    def test_get_deployment_statuses_diff_with_changes(self):
+        """Should return a complete report with the differences."""
+        previous_status = {
+            "processes": [
+                {"name": "proc-1", "image": "0.1.0-sha-1ab", "command": "npm start:proc-1"},
+                {"name": "proc-2", "image": "0.1.0-sha-1ab", "command": "npm start:proc-2"},
+            ],
+            "cronjobs": [
+                {
+                    "name": "cron-2",
+                    "image": "0.1.0-sha-1ab",
+                    "command": "npm start:cron-2",
+                    "schedule": "0 0 * * *",
+                },
+                {
+                    "name": "cron-3",
+                    "image": "0.1.0-sha-1ab",
+                    "command": "npm start:cron-3",
+                    "schedule": "0 * * * *",
+                },
+            ],
+            "env": [{"name": "VAR_A", "value": "VALUE_A"}, {"name": "VAR_B", "value": "VALUE_B"}],
+        }
+        new_status = {
+            "processes": [
+                {"name": "proc-1", "image": "0.1.0-sha-2cd", "command": "npm start:proc-1"},
+            ],
+            "cronjobs": [
+                {
+                    "name": "cron-1",
+                    "image": "0.1.0-sha-2cd",
+                    "command": "npm start:cron-1",
+                    "schedule": "0 * * * *",
+                },
+                {
+                    "name": "cron-2",
+                    "image": "0.1.0-sha-2cd",
+                    "command": "npm start:cron-2",
+                    "schedule": "0 0 * * *",
+                },
+            ],
+            "env": [
+                {"name": "VAR_B", "valueFrom": {"name": "my-app", "key": "VAR_B"}},
+                {"name": "VAR_C", "value": "VALUE_C"},
+            ],
+        }
+
+        diff = k8s_lib.get_deployement_statuses_diff(previous_status, new_status)
+
+        self.assertEqual(
+            diff,
+            {
+                "processes": {
+                    "added": [],
+                    "modified": [
+                        {
+                            "name": "proc-1",
+                            "values": {"image": {"old": "0.1.0-sha-1ab", "new": "0.1.0-sha-2cd"}},
+                        },
+                    ],
+                    "removed": [
+                        {"name": "proc-2", "image": "0.1.0-sha-1ab", "command": "npm start:proc-2"},
+                    ],
+                },
+                "cronjobs": {
+                    "added": [
+                        {
+                            "name": "cron-1",
+                            "image": "0.1.0-sha-2cd",
+                            "command": "npm start:cron-1",
+                            "schedule": "0 * * * *",
+                        },
+                    ],
+                    "modified": [
+                        {
+                            "name": "cron-2",
+                            "values": {"image": {"old": "0.1.0-sha-1ab", "new": "0.1.0-sha-2cd"}},
+                        },
+                    ],
+                    "removed": [
+                        {
+                            "name": "cron-3",
+                            "image": "0.1.0-sha-1ab",
+                            "command": "npm start:cron-3",
+                            "schedule": "0 * * * *",
+                        },
+                    ],
+                },
+                "env": {
+                    "added": [{"name": "VAR_C", "value": "VALUE_C"}],
+                    "modified": [
+                        {
+                            "name": "VAR_B",
+                            "value": {"old": "VALUE_B", "new": {"key": "VAR_B", "name": "my-app"}},
+                        },
+                    ],
+                    "removed": [{"name": "VAR_A", "value": "VALUE_A"}],
+                },
+            },
+        )
 
     def test_has_process_when_false(self):
         """Should return False."""

--- a/tests/lib/k8s/test_deployment.py
+++ b/tests/lib/k8s/test_deployment.py
@@ -2,14 +2,14 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import nestor_api.lib.k8s.deployment as k8s_lib
-from nestor_api.lib.k8s.enums.k8s_resource_type import K8sResourceType
+from nestor_api.lib.k8s.enums.k8s_resource_kind import K8sResourceKind
 import tests.__fixtures__.k8s as k8s_fixtures
 
 
 class TestK8sDeployment(TestCase):
     @patch("nestor_api.lib.k8s.deployment.write_and_deploy_configuration", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.deploy_app_ingress", autospec=True)
-    @patch("nestor_api.lib.k8s.deployment.get_deployement_statuses_diff", autospec=True)
+    @patch("nestor_api.lib.k8s.deployment.get_deployment_statuses_diff", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.get_deployment_status", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.K8sConfiguration", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.has_process", autospec=True)
@@ -19,8 +19,8 @@ class TestK8sDeployment(TestCase):
         builders_mock,
         has_web_process_mock,
         k8s_config_mock,
-        get_deployement_status_mock,
-        get_deployement_statuses_diff_mock,
+        get_deployment_status_mock,
+        get_deployment_statuses_diff_mock,
         deploy_app_ingress_mock,
         write_and_deploy_configuration_mock,
     ):
@@ -31,7 +31,7 @@ class TestK8sDeployment(TestCase):
         has_web_process_mock.return_value = True
         builders_mock.build_deployment_yaml.return_value = "deployment: app"
         report = {}
-        get_deployement_statuses_diff_mock.return_value = report
+        get_deployment_statuses_diff_mock.return_value = report
 
         # Setup
         deployment_config = {"cluster_name": "my-cluster"}
@@ -44,14 +44,14 @@ class TestK8sDeployment(TestCase):
 
         builders_mock.load_templates.assert_called_once_with("/config/templates-dir")
 
-        self.assertEqual(get_deployement_status_mock.call_count, 2)
-        get_deployement_statuses_diff_mock.assert_called_once()
+        self.assertEqual(get_deployment_status_mock.call_count, 2)
+        get_deployment_statuses_diff_mock.assert_called_once()
         deploy_app_ingress_mock.assert_called_once()
         write_and_deploy_configuration_mock.assert_called_once_with("my-cluster", "deployment: app")
 
     @patch("nestor_api.lib.k8s.deployment.write_and_deploy_configuration", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.deploy_app_ingress", autospec=True)
-    @patch("nestor_api.lib.k8s.deployment.get_deployement_statuses_diff", autospec=True)
+    @patch("nestor_api.lib.k8s.deployment.get_deployment_statuses_diff", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.get_deployment_status", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.K8sConfiguration", autospec=True)
     @patch("nestor_api.lib.k8s.deployment.has_process", autospec=True)
@@ -61,8 +61,8 @@ class TestK8sDeployment(TestCase):
         builders_mock,
         has_web_process_mock,
         k8s_config_mock,
-        get_deployement_status_mock,
-        get_deployement_statuses_diff_mock,
+        get_deployment_status_mock,
+        get_deployment_statuses_diff_mock,
         deploy_app_ingress_mock,
         write_and_deploy_configuration_mock,
     ):
@@ -73,7 +73,7 @@ class TestK8sDeployment(TestCase):
         has_web_process_mock.return_value = False
         builders_mock.build_deployment_yaml.return_value = "deployment: app"
         report = {}
-        get_deployement_statuses_diff_mock.return_value = report
+        get_deployment_statuses_diff_mock.return_value = report
 
         # Setup
         deployment_config = {"cluster_name": "my-cluster"}
@@ -86,8 +86,8 @@ class TestK8sDeployment(TestCase):
 
         builders_mock.load_templates.assert_called_once_with("/config/templates-dir")
 
-        self.assertEqual(get_deployement_status_mock.call_count, 2)
-        get_deployement_statuses_diff_mock.assert_called_once()
+        self.assertEqual(get_deployment_status_mock.call_count, 2)
+        get_deployment_statuses_diff_mock.assert_called_once()
 
         deploy_app_ingress_mock.assert_not_called()
         write_and_deploy_configuration_mock.assert_called_once_with("my-cluster", "deployment: app")
@@ -162,7 +162,7 @@ class TestK8sDeployment(TestCase):
             "my-cluster",
             "my-namespace",
             "my-app",
-            [K8sResourceType.DEPLOYMENTS, K8sResourceType.CRONJOBS],
+            [K8sResourceKind.DEPLOYMENT, K8sResourceKind.CRONJOB],
         )
 
     @patch("nestor_api.lib.k8s.deployment.cli", autospec=True)
@@ -186,7 +186,7 @@ class TestK8sDeployment(TestCase):
             "my-cluster",
             "my-namespace",
             "my-app",
-            [K8sResourceType.DEPLOYMENTS, K8sResourceType.CRONJOBS],
+            [K8sResourceKind.DEPLOYMENT, K8sResourceKind.CRONJOB],
         )
 
     @patch("nestor_api.lib.k8s.deployment.cli", autospec=True)
@@ -225,7 +225,7 @@ class TestK8sDeployment(TestCase):
             "my-cluster",
             "my-namespace",
             "my-app",
-            [K8sResourceType.DEPLOYMENTS, K8sResourceType.CRONJOBS],
+            [K8sResourceKind.DEPLOYMENT, K8sResourceKind.CRONJOB],
         )
 
     @patch("nestor_api.lib.k8s.deployment.cli", autospec=True)
@@ -264,7 +264,7 @@ class TestK8sDeployment(TestCase):
         }
         new_status = previous_status
 
-        diff = k8s_lib.get_deployement_statuses_diff(previous_status, new_status)
+        diff = k8s_lib.get_deployment_statuses_diff(previous_status, new_status)
 
         self.assertEqual(
             diff,
@@ -322,7 +322,7 @@ class TestK8sDeployment(TestCase):
             ],
         }
 
-        diff = k8s_lib.get_deployement_statuses_diff(previous_status, new_status)
+        diff = k8s_lib.get_deployment_statuses_diff(previous_status, new_status)
 
         self.assertEqual(
             diff,

--- a/tests/utils/test_list.py
+++ b/tests/utils/test_list.py
@@ -4,6 +4,95 @@ import nestor_api.utils.list as list_utils
 
 
 class TestListUtil(TestCase):
+    def test_compute_diff_when_both_empty(self):
+        """Should return empty report."""
+        list_1 = []
+        list_2 = []
+
+        result = list_utils.compute_diff(list_1, list_2)
+
+        self.assertEqual(list_1, [])
+        self.assertEqual(list_2, [])
+        self.assertEqual(result, {"added": [], "modified": [], "removed": []})
+
+    def test_compute_diff_when_first_empty(self):
+        """Should consider all members of list_2 as "added" and sort them."""
+        list_1 = []
+        list_2 = [3, 2, 1]
+
+        result = list_utils.compute_diff(list_1, list_2)
+
+        self.assertEqual(list_1, [])
+        self.assertEqual(list_2, [3, 2, 1])
+        self.assertEqual(result, {"added": [1, 2, 3], "modified": [], "removed": []})
+
+    def test_compute_diff_when_second_empty(self):
+        """Should consider all members of list_1 as "removed" and sort them."""
+        list_1 = [3, 2, 1]
+        list_2 = []
+
+        result = list_utils.compute_diff(list_1, list_2)
+
+        self.assertEqual(list_1, [3, 2, 1])
+        self.assertEqual(list_2, [])
+        self.assertEqual(result, {"added": [], "modified": [], "removed": [1, 2, 3]})
+
+    def test_compute_diff_with_additions_and_deletions(self):
+        """Should correctly find the added and removed items."""
+        list_1 = [1, 3, 5, 6]
+        list_2 = [2, 3, 4, 6, 7]
+
+        result = list_utils.compute_diff(list_1, list_2)
+
+        self.assertEqual(list_1, [1, 3, 5, 6])
+        self.assertEqual(list_2, [2, 3, 4, 6, 7])
+        self.assertEqual(result, {"added": [2, 4, 7], "modified": [], "removed": [1, 5]})
+
+    def test_compute_diff_with_custom_key(self):
+        """Should correctly match the modified values."""
+        list_1 = ["a", "b", "c"]
+        list_2 = ["A", "B", "C"]
+        key_getter = lambda x: x.lower()  # The keys will match but not the values
+
+        result = list_utils.compute_diff(list_1, list_2, key=key_getter)
+
+        self.assertEqual(list_1, ["a", "b", "c"])
+        self.assertEqual(list_2, ["A", "B", "C"])
+        self.assertEqual(
+            result,
+            {
+                "added": [],
+                "modified": [
+                    {"old": "a", "new": "A"},
+                    {"old": "b", "new": "B"},
+                    {"old": "c", "new": "C"},
+                ],
+                "removed": [],
+            },
+        )
+
+    def test_compute_diff_with_complex_values(self):
+        """Should correctly use the provided comparator."""
+        list_1 = [{"key": "a", "value": 1}, {"key": "b", "value": 1}, {"key": "c", "value": 1}]
+        list_2 = [{"key": "b", "value": 1}, {"key": "c", "value": 2}, {"key": "d", "value": 2}]
+        key_getter = lambda x: x["key"]
+        comparator = (
+            lambda v1, v2: None
+            if v1["value"] == v2["value"]
+            else {v1["key"]: {"old": v1["value"], "new": v2["value"]}}
+        )
+
+        result = list_utils.compute_diff(list_1, list_2, key=key_getter, comparator=comparator)
+
+        self.assertEqual(
+            result,
+            {
+                "added": [{"key": "d", "value": 2}],
+                "modified": [{"c": {"old": 1, "new": 2}}],
+                "removed": [{"key": "a", "value": 1}],
+            },
+        )
+
     def test_flatten(self):
         """Should correctly flatten the given list."""
         double_list = [[1, 2], [3, 4], [5, 6]]


### PR DESCRIPTION
Creates an object holding the key changes between 2 deployments : namely, `previous_status` and `current_status`.

This PR is divided in 3 commits that can be reviewed independently :
- The first one adds an utility function to compare 2 list of items;
- The second one adds function fetching the status of a deployment and creating a summary object;
- The third one adds a function computing a diff between 2 summaries : `added`/`modified`/`removed` resources.